### PR TITLE
Fixing Issue 89 - space characters missing

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -86,7 +86,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.ts
-    begin: '(?:\s+(extends|implements)\b)'
+    begin: '(?:\s+\b(extends|implements)\b\s+)'
     beginCaptures:
       '1': { name: keyword.other.ts }
     end: (?=\{)

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -86,7 +86,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.ts
-    begin: '(?:\s*\b(extends|implements)\b\s*)'
+    begin: '(?:\s+\b(extends|implements)\b\s+)'
     beginCaptures:
       '1': { name: keyword.other.ts }
     end: (?=\{)

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -86,7 +86,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.ts
-    begin: '(?:\s+\b(extends|implements)\b\s+)'
+    begin: '(?:\s+(extends|implements)\b)'
     beginCaptures:
       '1': { name: keyword.other.ts }
     end: (?=\{)

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -86,7 +86,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.ts
-    begin: '(?:\b(extends|implements))'
+    begin: '(?:\s*\b(extends|implements)\b\s*)'
     beginCaptures:
       '1': { name: keyword.other.ts }
     end: (?=\{)

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -998,7 +998,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\b(extends|implements))</string>
+			<string>(?:\s*\b(extends|implements)\b\s*)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -998,7 +998,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s+(extends|implements)\b)</string>
+			<string>(?:\s+\b(extends|implements)\b\s+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -998,7 +998,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s+\b(extends|implements)\b\s+)</string>
+			<string>(?:\s+(extends|implements)\b)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -998,7 +998,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s*\b(extends|implements)\b\s*)</string>
+			<string>(?:\s+\b(extends|implements)\b\s+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -88,7 +88,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.tsx
-    begin: '(?:\s*\b(extends|implements)\b\s*)'
+    begin: '(?:\s+\b(extends|implements)\b\s+)'
     beginCaptures:
       '1': { name: keyword.other.tsx }
     end: (?=\{)

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -88,7 +88,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.tsx
-    begin: '(?:\s+\b(extends|implements)\b\s+)'
+    begin: '(?:\s+(extends|implements)\b)'
     beginCaptures:
       '1': { name: keyword.other.tsx }
     end: (?=\{)

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -88,7 +88,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.tsx
-    begin: '(?:\b(extends|implements))'
+    begin: '(?:\s*\b(extends|implements)\b\s*)'
     beginCaptures:
       '1': { name: keyword.other.tsx }
     end: (?=\{)

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -88,7 +88,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.tsx
-    begin: '(?:\s+(extends|implements)\b)'
+    begin: '(?:\s+\b(extends|implements)\b\s+)'
     beginCaptures:
       '1': { name: keyword.other.tsx }
     end: (?=\{)

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1364,7 +1364,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\b(extends|implements))</string>
+			<string>(?:\s*\b(extends|implements)\b\s*)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1364,7 +1364,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s+(extends|implements)\b)</string>
+			<string>(?:\s+\b(extends|implements)\b\s+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1364,7 +1364,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s+\b(extends|implements)\b\s+)</string>
+			<string>(?:\s+(extends|implements)\b)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1364,7 +1364,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s*\b(extends|implements)\b\s*)</string>
+			<string>(?:\s+\b(extends|implements)\b\s+)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/tests/cases/Issue89.ts
+++ b/tests/cases/Issue89.ts
@@ -1,6 +1,0 @@
-// Issue #89
-
-export class FileLogger extends class implements /* Commment */ IDisposable{
-		//Comment
-}
-//Comment

--- a/tests/cases/Issue89.ts
+++ b/tests/cases/Issue89.ts
@@ -1,0 +1,6 @@
+// Issue #89
+
+export class FileLogger extends class implements /* Commment */ IDisposable{
+		//Comment
+}
+//Comment


### PR DESCRIPTION
Space characters were missing - Changed the begin clause under 'object-heritage' to account for space characters. 