### PR TITLE
Fixes the color of the switch keyword.

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -412,7 +412,7 @@ repository:
     name: switch-expression.expr.ts
     begin: \b(switch)\b\s*\(
     beginCaptures:
-      '1': { name: keyword.operator.ts }
+      '1': { name: keyword.control.ts }
     end: \)
     patterns:
     - include: '#expression'

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1293,7 +1293,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.ts</string>
+					<string>keyword.control.ts</string>
 				</dict>
 			</dict>
 			<key>end</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -414,7 +414,7 @@ repository:
     name: switch-expression.expr.tsx
     begin: \b(switch)\b\s*\(
     beginCaptures:
-      '1': { name: keyword.operator.tsx }
+      '1': { name: keyword.control.tsx }
     end: \)
     patterns:
     - include: '#expression'

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1659,7 +1659,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>keyword.operator.tsx</string>
+					<string>keyword.control.tsx</string>
 				</dict>
 			</dict>
 			<key>end</key>

--- a/tests/baselines/javascript.txt
+++ b/tests/baselines/javascript.txt
@@ -1,0 +1,7 @@
+[1, 1]: source.ts switch-statement.expr.ts switch-expression.expr.ts keyword.control.ts 
+[2, 5]: source.ts switch-statement.expr.ts switch-block.expr.ts case-clause.expr.ts keyword.control.ts 
+[3, 5]: source.ts switch-statement.expr.ts switch-block.expr.ts case-clause.expr.ts keyword.control.ts 
+[5, 1]: source.ts keyword.operator.ts 
+[6, 1]: source.ts keyword.operator.ts 
+[7, 1]: source.ts keyword.operator.ts 
+[8, 3]: source.ts keyword.operator.ts 

--- a/tests/cases/javascript.ts
+++ b/tests/cases/javascript.ts
@@ -1,0 +1,8 @@
+^^switch (x) {
+    ^^case 0:
+    ^^default:
+}
+^^typeof x;
+^^void x;
+^^delete x.y;
+x ^^instanceof y;


### PR DESCRIPTION
We classify `switch` as `keyword.control.ts` in `#control-statement`, but as `keyword.operator.ts` in `#switch-expression`. 

This change modifies `#switch-expression` so that the `switch` keyword is colored as `keyword.control.ts` in both TypeScript and TypeScriptReact syntaxes.