### PR TITLE
Solving Issue 44 - Changed scope name for type references

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -48,7 +48,7 @@ repository:
     begin: \b(type)\b\s+([a-zA-Z_$][\w$]*)\s*
     beginCaptures:
       '1': { name: keyword.other.ts }
-      '2': { name: storage.type.ts }
+      '2': { name: support.type.ts }
     end: (?=$|[,);>]|var|type|function|class|interface)
     patterns:
       - include: '#type-parameters'
@@ -105,7 +105,7 @@ repository:
     name: meta.object.heritage.parent.ts
     match: '(?:\s*([a-zA-Z_$][\w$]*)\b)'
     captures:
-      '1': { name: storage.type.ts }
+      '1': { name: support.type.ts }
 
   object-body:
     name: meta.object.body.ts
@@ -307,7 +307,7 @@ repository:
     name: meta.type.primitive.ts
     match: '\b(string|number|boolean|symbol|any|void)\b'
     captures:
-      '1': { name: storage.type.ts }
+      '1': { name: support.type.ts }
 
   # Parenthesis can contain either types and function parameters
   # (number | string) or (param: number, param2: string)
@@ -404,6 +404,7 @@ repository:
     - include: '#logic-operator'
     - include: '#assignment-operator'
     - include: '#storage-keyword'
+    - include: '#type-primitive'
     - include: '#function-call'
     - include: '#case-clause'
     - include: '#control-statement'
@@ -510,7 +511,7 @@ repository:
 
   storage-keyword:
     name: storage.type.ts
-    match: \b(number|boolean|string|any|var|let|function|const|module|namespace)\b
+    match: \b(var|let|function|const|module|namespace)\b
 
   paren-expression:
     begin: \(

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -393,6 +393,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#type-primitive</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#function-call</string>
 				</dict>
 				<dict>
@@ -1046,7 +1050,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.ts</string>
+					<string>support.type.ts</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -1241,7 +1245,7 @@
 		<key>storage-keyword</key>
 		<dict>
 			<key>match</key>
-			<string>\b(number|boolean|string|any|var|let|function|const|module|namespace)\b</string>
+			<string>\b(var|let|function|const|module|namespace)\b</string>
 			<key>name</key>
 			<string>storage.type.ts</string>
 		</dict>
@@ -1497,7 +1501,7 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.ts</string>
+					<string>support.type.ts</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -1702,7 +1706,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.ts</string>
+					<string>support.type.ts</string>
 				</dict>
 			</dict>
 			<key>match</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -50,7 +50,7 @@ repository:
     begin: \b(type)\b\s+([a-zA-Z_$][\w$]*)\s*
     beginCaptures:
       '1': { name: keyword.other.tsx }
-      '2': { name: storage.type.tsx }
+      '2': { name: support.type.tsx }
     end: (?=$|[,);>]|var|type|function|class|interface)
     patterns:
       - include: '#type-parameters'
@@ -107,7 +107,7 @@ repository:
     name: meta.object.heritage.parent.tsx
     match: '(?:\s*([a-zA-Z_$][\w$]*)\b)'
     captures:
-      '1': { name: storage.type.tsx }
+      '1': { name: support.type.tsx }
 
   object-body:
     name: meta.object.body.tsx
@@ -309,7 +309,7 @@ repository:
     name: meta.type.primitive.tsx
     match: '\b(string|number|boolean|symbol|any|void)\b'
     captures:
-      '1': { name: storage.type.tsx }
+      '1': { name: support.type.tsx }
 
   # Parenthesis can contain either types and function parameters
   # (number | string) or (param: number, param2: string)
@@ -406,6 +406,7 @@ repository:
     - include: '#logic-operator'
     - include: '#assignment-operator'
     - include: '#storage-keyword'
+    - include: '#type-primitive'
     - include: '#function-call'
     - include: '#case-clause'
     - include: '#control-statement'
@@ -498,7 +499,7 @@ repository:
 
   storage-keyword:
     name: storage.type.tsx
-    match: \b(number|boolean|string|any|var|let|function|const|module|namespace)\b
+    match: \b(var|let|function|const|module|namespace)\b
 
   paren-expression:
     begin: \(

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -361,6 +361,10 @@
 				</dict>
 				<dict>
 					<key>include</key>
+					<string>#type-primitive</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#function-call</string>
 				</dict>
 				<dict>
@@ -1412,7 +1416,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.tsx</string>
+					<string>support.type.tsx</string>
 				</dict>
 			</dict>
 			<key>match</key>
@@ -1607,7 +1611,7 @@
 		<key>storage-keyword</key>
 		<dict>
 			<key>match</key>
-			<string>\b(number|boolean|string|any|var|let|function|const|module|namespace)\b</string>
+			<string>\b(var|let|function|const|module|namespace)\b</string>
 			<key>name</key>
 			<string>storage.type.tsx</string>
 		</dict>
@@ -1863,7 +1867,7 @@
 				<key>2</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.tsx</string>
+					<string>support.type.tsx</string>
 				</dict>
 			</dict>
 			<key>end</key>
@@ -2068,7 +2072,7 @@
 				<key>1</key>
 				<dict>
 					<key>name</key>
-					<string>storage.type.tsx</string>
+					<string>support.type.tsx</string>
 				</dict>
 			</dict>
 			<key>match</key>

--- a/tests/baselines/ArrowFunctionInsideTypeAssertion.txt
+++ b/tests/baselines/ArrowFunctionInsideTypeAssertion.txt
@@ -3,15 +3,15 @@
 [4, 21]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.paren.cover.ts meta.type.name.ts 
 [4, 30]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.paren.cover.ts meta.type.name.ts 
 [4, 43]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.paren.cover.ts meta.type.name.ts 
-[4, 57]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.paren.cover.ts meta.type.primitive.ts storage.type.ts 
+[4, 57]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.paren.cover.ts meta.type.primitive.ts support.type.ts 
 [4, 65]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts keyword.operator.ts 
-[4, 68]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts meta.type.primitive.ts storage.type.ts 
+[4, 68]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts meta.type.primitive.ts support.type.ts 
 [4, 73]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.block.ts meta.object.member.ts constant.language.null.ts 
 [17, 17]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.brace.angle.ts 
 [17, 18]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.paren.cover.ts 
 [17, 19]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.paren.cover.ts meta.type.name.ts 
-[17, 22]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.paren.cover.ts meta.type.primitive.ts storage.type.ts 
+[17, 22]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.paren.cover.ts meta.type.primitive.ts support.type.ts 
 [17, 30]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts keyword.operator.ts 
-[17, 33]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts meta.type.primitive.ts storage.type.ts 
+[17, 33]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts meta.type.primitive.ts support.type.ts 
 [17, 39]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.brace.angle.ts 
 [17, 41]: source.ts meta.function.ts meta.decl.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts 

--- a/tests/baselines/Issue149.txt
+++ b/tests/baselines/Issue149.txt
@@ -1,6 +1,6 @@
 [1, 1]: source.ts meta.function.ts storage.modifier.ts 
 [1, 17]: source.ts meta.function.ts entity.name.function.ts 
-[1, 23]: source.ts meta.function.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts storage.type.ts 
+[1, 23]: source.ts meta.function.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts support.type.ts 
 [1, 32]: source.ts meta.function.ts meta.return.type.ts meta.type.paren.cover.ts keyword.control.ts 
 [1, 41]: source.ts meta.function.ts meta.return.type.ts meta.type.function.return.ts meta.type.name.ts 
 [2, 1]: source.ts meta.function.ts meta.function.overload.ts storage.modifier.ts 

--- a/tests/baselines/Issue156.txt
+++ b/tests/baselines/Issue156.txt
@@ -1,7 +1,7 @@
 [2, 2]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts entity.name.function.ts 
 [2, 6]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts variable.parameter.ts 
-[2, 10]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts storage.type.ts 
+[2, 10]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts support.type.ts 
 [2, 19]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.object.type.ts meta.brace.curly.ts 
 [2, 23]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts variable.parameter.ts 
-[2, 27]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts storage.type.ts 
+[2, 27]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts support.type.ts 
 [4, 9]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts 

--- a/tests/baselines/Issue191.txt
+++ b/tests/baselines/Issue191.txt
@@ -1,9 +1,9 @@
 [2, 5]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts entity.name.function.ts 
 [2, 17]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts storage.modifier.ts 
 [2, 24]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts variable.parameter.ts 
-[2, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts storage.type.ts 
+[2, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts support.type.ts 
 [3, 13]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.ts 
-[3, 28]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[3, 28]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [3, 37]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.paren.ts 
 [4, 9]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts constant.language.this.ts 
 [4, 26]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts new.expr.ts meta.type.name.ts 
@@ -18,9 +18,9 @@
 [12, 5]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts entity.name.function.ts 
 [12, 17]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts storage.modifier.ts 
 [12, 24]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts variable.parameter.ts 
-[12, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts storage.type.ts 
+[12, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts support.type.ts 
 [13, 13]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.ts 
-[13, 28]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[13, 28]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [13, 37]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.paren.ts 
 [14, 9]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts constant.language.this.ts 
 [14, 26]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts new.expr.ts meta.type.name.ts 

--- a/tests/baselines/Issue208.txt
+++ b/tests/baselines/Issue208.txt
@@ -1,25 +1,25 @@
 [1, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.ts 
 [1, 19]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts entity.name.type.ts 
-[1, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
-[1, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[1, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
+[1, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [1, 42]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.single.ts 
 [1, 47]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.paren.ts 
 [2, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts entity.name.type.ts 
-[2, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
-[2, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[2, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
+[2, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [2, 42]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.single.ts 
 [2, 47]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.paren.ts 
 [5, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts variable.ts 
 [5, 27]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts entity.name.type.ts 
-[5, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
-[5, 41]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[5, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
+[5, 41]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [6, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts variable.ts 
 [6, 23]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts entity.name.type.ts 
-[6, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
-[6, 41]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[6, 33]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
+[6, 41]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [8, 20]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts entity.name.type.ts 
-[8, 26]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
-[8, 34]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[8, 26]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
+[8, 34]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts new.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [9, 16]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts entity.name.type.ts 
-[9, 26]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
-[9, 34]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[9, 26]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
+[9, 34]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 

--- a/tests/baselines/Issue44.txt
+++ b/tests/baselines/Issue44.txt
@@ -1,0 +1,7 @@
+[2, 1]: source.ts meta.declaration.object.ts storage.type.ts 
+[2, 11]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
+[3, 3]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts variable.ts 
+[3, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts meta.type.primitive.ts support.type.ts 
+[4, 3]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts entity.name.function.ts 
+[4, 15]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.type.annotation.ts meta.type.primitive.ts support.type.ts 
+[5, 1]: source.ts meta.declaration.object.ts meta.object.body.ts meta.brace.curly.ts 

--- a/tests/baselines/Issue63.txt
+++ b/tests/baselines/Issue63.txt
@@ -1,28 +1,28 @@
 [1, 1]: source.ts meta.type.declaration.ts keyword.other.ts 
-[1, 6]: source.ts meta.type.declaration.ts storage.type.ts 
+[1, 6]: source.ts meta.type.declaration.ts support.type.ts 
 [1, 16]: source.ts meta.type.declaration.ts meta.type.parameters.ts meta.type.name.ts 
 [1, 21]: source.ts meta.type.declaration.ts meta.type.paren.cover.ts 
 [3, 1]: source.ts meta.type.declaration.ts keyword.other.ts 
 [3, 14]: source.ts meta.type.declaration.ts meta.type.parameters.ts meta.brace.angle.ts 
 [3, 21]: source.ts meta.type.declaration.ts meta.type.paren.cover.ts 
 [3, 46]: source.ts meta.type.declaration.ts meta.type.function.return.ts keyword.operator.ts 
-[3, 49]: source.ts meta.type.declaration.ts meta.type.function.return.ts meta.type.primitive.ts storage.type.ts 
+[3, 49]: source.ts meta.type.declaration.ts meta.type.function.return.ts meta.type.primitive.ts support.type.ts 
 [5, 17]: source.ts meta.type.declaration.ts meta.type.paren.cover.ts 
-[5, 45]: source.ts meta.type.declaration.ts meta.type.function.return.ts meta.type.primitive.ts storage.type.ts 
+[5, 45]: source.ts meta.type.declaration.ts meta.type.function.return.ts meta.type.primitive.ts support.type.ts 
 [7, 1]: source.ts meta.type.declaration.ts keyword.other.ts 
-[7, 6]: source.ts meta.type.declaration.ts storage.type.ts 
+[7, 6]: source.ts meta.type.declaration.ts support.type.ts 
 [7, 14]: source.ts meta.type.declaration.ts meta.type.parameters.ts meta.brace.angle.ts 
 [7, 22]: source.ts meta.type.declaration.ts meta.type.parameters.ts keyword.operator.type.ts 
 [7, 24]: source.ts meta.type.declaration.ts meta.type.parameters.ts meta.type.paren.cover.ts 
-[7, 50]: source.ts meta.type.declaration.ts meta.type.parameters.ts meta.type.function.return.ts meta.type.primitive.ts storage.type.ts 
+[7, 50]: source.ts meta.type.declaration.ts meta.type.parameters.ts meta.type.function.return.ts meta.type.primitive.ts support.type.ts 
 [7, 58]: source.ts meta.type.declaration.ts meta.type.paren.cover.ts 
-[7, 86]: source.ts meta.type.declaration.ts meta.type.function.return.ts meta.type.primitive.ts storage.type.ts 
+[7, 86]: source.ts meta.type.declaration.ts meta.type.function.return.ts meta.type.primitive.ts support.type.ts 
 [9, 1]: source.ts 
-[9, 7]: source.ts meta.type.declaration.ts storage.type.ts 
+[9, 7]: source.ts meta.type.declaration.ts support.type.ts 
 [9, 12]: source.ts meta.type.declaration.ts meta.type.parameters.ts meta.type.name.ts 
 [9, 18]: source.ts meta.type.declaration.ts meta.object.type.ts meta.brace.curly.ts 
 [11, 2]: source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts variable.ts 
 [11, 7]: source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts 
 [12, 2]: source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts variable.ts 
-[12, 7]: source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts storage.type.ts 
+[12, 7]: source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts meta.type.primitive.ts support.type.ts 
 [14, 1]: source.ts meta.type.declaration.ts meta.object.type.ts meta.brace.curly.ts 

--- a/tests/baselines/Issue82.txt
+++ b/tests/baselines/Issue82.txt
@@ -1,5 +1,5 @@
 [3, 9]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts variable.parameter.ts 
-[3, 15]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts storage.type.ts 
+[3, 15]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.primitive.ts support.type.ts 
 [3, 25]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts comment.line.ts 
 [4, 9]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts parameter.name.ts variable.parameter.ts 
 [4, 31]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.function.type.parameter.ts meta.type.annotation.ts meta.type.paren.cover.ts 

--- a/tests/baselines/Issue89.txt
+++ b/tests/baselines/Issue89.txt
@@ -2,26 +2,26 @@
 [1, 14]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
 [1, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
 [1, 27]: source.ts meta.declaration.object.ts meta.object.heritage.ts comment.block.ts 
-[1, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[1, 32]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[1, 47]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[1, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
+[1, 32]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
+[1, 47]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [2, 2]: source.ts meta.declaration.object.ts meta.object.body.ts 
 [4, 1]: source.ts 
 [7, 14]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
 [7, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
 [7, 31]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts 
-[7, 34]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[7, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[7, 34]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
+[7, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [7, 48]: source.ts meta.declaration.object.ts meta.object.heritage.ts 
 [8, 2]: source.ts meta.declaration.object.ts meta.object.body.ts 
 [10, 1]: source.ts 
 [12, 14]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
 [12, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
-[12, 28]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[12, 28]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [12, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts 
 [12, 43]: source.ts meta.declaration.object.ts meta.object.heritage.ts comment.block.ts 
-[12, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[12, 51]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[12, 56]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[12, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
+[12, 51]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
+[12, 56]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [13, 2]: source.ts meta.declaration.object.ts meta.object.body.ts 
 [15, 1]: source.ts 

--- a/tests/baselines/pr48_noSemiColon.txt
+++ b/tests/baselines/pr48_noSemiColon.txt
@@ -6,7 +6,7 @@
 [4, 10]: source.ts meta.declaration.object.ts meta.object.body.ts meta.field.declaration.ts variable.ts 
 [7, 1]: source.ts keyword.operator.ts 
 [7, 8]: source.ts meta.type.declaration.ts keyword.other.ts 
-[7, 13]: source.ts meta.type.declaration.ts storage.type.ts 
+[7, 13]: source.ts meta.type.declaration.ts support.type.ts 
 [8, 1]: source.ts keyword.operator.ts 
 [8, 8]: source.ts meta.var.expr.ts storage.type.ts 
 [8, 14]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.ts 
@@ -16,7 +16,7 @@
 [14, 2]: source.ts meta.function.ts meta.decl.block.ts keyword.control.ts 
 [18, 1]: source.ts keyword.operator.ts 
 [18, 8]: source.ts meta.var.expr.ts storage.type.ts 
-[18, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[18, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 
 [19, 1]: source.ts keyword.operator.ts 
 [19, 8]: source.ts meta.var.expr.ts storage.type.ts 
-[19, 34]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts storage.type.ts 
+[19, 34]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts meta.type.primitive.ts support.type.ts 

--- a/tests/cases/Issue44.ts
+++ b/tests/cases/Issue44.ts
@@ -1,0 +1,9 @@
+
+^^interface ^^TestInterface {
+  ^^testvar: ^^string;
+  ^^testfunc(): ^^string;
+^^}
+
+/*
+	Testing Comments
+*/


### PR DESCRIPTION
Solving Issue #44,
- using ‘storage.type’ only for JS keywords like function, var, let, const
- using ‘support.type‘ for the type declaration