### PR TITLE
Correctly classify keywords in object-heritage clauses

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -89,7 +89,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.ts
-    begin: '(?:\b(extends|implements)\b)'
+    begin: '(?:\s*\b(extends|implements)\b)'
     beginCaptures:
       '1': { name: keyword.other.ts }
     end: (?=\{)

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -89,7 +89,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.ts
-    begin: '(?:\s*\b(extends|implements)\b)'
+    begin: '(?:\b(extends|implements)\b)'
     beginCaptures:
       '1': { name: keyword.other.ts }
     end: (?=\{)
@@ -103,7 +103,7 @@ repository:
 
   object-heritage-type:
     name: meta.object.heritage.parent.ts
-    match: '(?:\s*([a-zA-Z_$][\w$]*)\b)'
+    match: '(?:\b([a-zA-Z_$][\w$]*)\b)'
     captures:
       '1': { name: support.type.ts }
 

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -998,7 +998,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\b(extends|implements)\b)</string>
+			<string>(?:\s*\b(extends|implements)\b)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1012,7 +1012,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s*\b(extends|implements)\b)</string>
+			<string>(?:\b(extends|implements)\b)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1064,7 +1064,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?:\s*([a-zA-Z_$][\w$]*)\b)</string>
+			<string>(?:\b([a-zA-Z_$][\w$]*)\b)</string>
 			<key>name</key>
 			<string>meta.object.heritage.parent.ts</string>
 		</dict>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -91,7 +91,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.tsx
-    begin: '(?:\b(extends|implements)\b)'
+    begin: '(?:\s*\b(extends|implements)\b)'
     beginCaptures:
       '1': { name: keyword.other.tsx }
     end: (?=\{)

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -91,7 +91,7 @@ repository:
 
   object-heritage:
     name: meta.object.heritage.tsx
-    begin: '(?:\s*\b(extends|implements)\b)'
+    begin: '(?:\b(extends|implements)\b)'
     beginCaptures:
       '1': { name: keyword.other.tsx }
     end: (?=\{)
@@ -105,7 +105,7 @@ repository:
 
   object-heritage-type:
     name: meta.object.heritage.parent.tsx
-    match: '(?:\s*([a-zA-Z_$][\w$]*)\b)'
+    match: '(?:\b([a-zA-Z_$][\w$]*)\b)'
     captures:
       '1': { name: support.type.tsx }
 

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1364,7 +1364,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\b(extends|implements)\b)</string>
+			<string>(?:\s*\b(extends|implements)\b)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1378,7 +1378,7 @@
 		<key>object-heritage</key>
 		<dict>
 			<key>begin</key>
-			<string>(?:\s*\b(extends|implements)\b)</string>
+			<string>(?:\b(extends|implements)\b)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>
@@ -1430,7 +1430,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>(?:\s*([a-zA-Z_$][\w$]*)\b)</string>
+			<string>(?:\b([a-zA-Z_$][\w$]*)\b)</string>
 			<key>name</key>
 			<string>meta.object.heritage.parent.tsx</string>
 		</dict>

--- a/tests/baselines/Issue89.txt
+++ b/tests/baselines/Issue89.txt
@@ -9,7 +9,7 @@
 [4, 1]: source.ts 
 [7, 14]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
 [7, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
-[7, 31]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts 
+[7, 31]: source.ts meta.declaration.object.ts meta.object.heritage.ts 
 [7, 34]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts keyword.other.ts 
 [7, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [7, 48]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts 
@@ -18,10 +18,18 @@
 [12, 14]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
 [12, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
 [12, 28]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
-[12, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts 
+[12, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts 
 [12, 43]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts comment.block.ts 
 [12, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [12, 51]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [12, 56]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
 [13, 2]: source.ts meta.declaration.object.ts meta.object.body.ts 
 [15, 1]: source.ts 
+[17, 1]: source.ts meta.declaration.object.ts storage.type.ts 
+[17, 7]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
+[17, 17]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
+[17, 25]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
+[17, 32]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts keyword.other.ts 
+[17, 43]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts support.type.ts 
+[18, 5]: source.ts meta.declaration.object.ts meta.object.body.ts 
+[22, 20]: source.ts comment.block.ts 

--- a/tests/baselines/Issue89.txt
+++ b/tests/baselines/Issue89.txt
@@ -3,25 +3,25 @@
 [1, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
 [1, 27]: source.ts meta.declaration.object.ts meta.object.heritage.ts comment.block.ts 
 [1, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[1, 32]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[1, 47]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[1, 32]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts keyword.other.ts 
+[1, 47]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
 [2, 2]: source.ts meta.declaration.object.ts meta.object.body.ts 
 [4, 1]: source.ts 
 [7, 14]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
 [7, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
 [7, 31]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts 
-[7, 34]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[7, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[7, 48]: source.ts meta.declaration.object.ts meta.object.heritage.ts 
+[7, 34]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts keyword.other.ts 
+[7, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[7, 48]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts 
 [8, 2]: source.ts meta.declaration.object.ts meta.object.body.ts 
 [10, 1]: source.ts 
 [12, 14]: source.ts meta.declaration.object.ts meta.object.name.ts entity.name.class.ts 
 [12, 16]: source.ts meta.declaration.object.ts meta.object.heritage.ts keyword.other.ts 
 [12, 28]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[12, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts 
-[12, 43]: source.ts meta.declaration.object.ts meta.object.heritage.ts comment.block.ts 
-[12, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[12, 51]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
-[12, 56]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[12, 30]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts 
+[12, 43]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts comment.block.ts 
+[12, 46]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[12, 51]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
+[12, 56]: source.ts meta.declaration.object.ts meta.object.heritage.ts meta.object.heritage.ts meta.object.heritage.parent.ts storage.type.ts 
 [13, 2]: source.ts meta.declaration.object.ts meta.object.body.ts 
 [15, 1]: source.ts 

--- a/tests/cases/Issue89.ts
+++ b/tests/cases/Issue89.ts
@@ -13,3 +13,11 @@ export class ^^E ^^extends /**/^^H ^^ implements/*^^*/ ^^One, ^^Two, ^^Three{
 	^^	
 }
 ^^
+
+^^class ^^className ^^extends ^^class1 ^^implements ^^class2 {
+    ^^
+}
+
+/*
+	Checking comments ^^
+*/


### PR DESCRIPTION
Solving Issue #38 / #89. 
Improving upon the previous pull request #99