### PR TITLE
Allowing numbers in exponential notation to be scoped as numeric literals

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -631,7 +631,7 @@ repository:
 
   numeric-literal:
     name: constant.numeric.ts
-    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))\b
+    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b
 
   boolean-literal:
     name: constant.language.boolean.ts

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -631,7 +631,7 @@ repository:
 
   numeric-literal:
     name: constant.numeric.ts
-    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b
+    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))([eE]([+-]?)[0-9]+(\.[0-9]+)?)?)\b
 
   boolean-literal:
     name: constant.language.boolean.ts

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -869,7 +869,7 @@
 		<key>numeric-literal</key>
 		<dict>
 			<key>match</key>
-			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b</string>
+			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))([eE]([+-]?)[0-9]+(\.[0-9]+)?)?)\b</string>
 			<key>name</key>
 			<string>constant.numeric.ts</string>
 		</dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -869,7 +869,7 @@
 		<key>numeric-literal</key>
 		<dict>
 			<key>match</key>
-			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))\b</string>
+			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b</string>
 			<key>name</key>
 			<string>constant.numeric.ts</string>
 		</dict>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -619,7 +619,7 @@ repository:
 
   numeric-literal:
     name: constant.numeric.tsx
-    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b
+    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))([eE]([+-]?)[0-9]+(\.[0-9]+)?)?)\b
 
   boolean-literal:
     name: constant.language.boolean.tsx

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -619,7 +619,7 @@ repository:
 
   numeric-literal:
     name: constant.numeric.tsx
-    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))\b
+    match: \b(?<=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b
 
   boolean-literal:
     name: constant.language.boolean.tsx

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1235,7 +1235,7 @@
 		<key>numeric-literal</key>
 		<dict>
 			<key>match</key>
-			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b</string>
+			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))([eE]([+-]?)[0-9]+(\.[0-9]+)?)?)\b</string>
 			<key>name</key>
 			<string>constant.numeric.tsx</string>
 		</dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1235,7 +1235,7 @@
 		<key>numeric-literal</key>
 		<dict>
 			<key>match</key>
-			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))\b</string>
+			<string>\b(?&lt;=[^$])((0(x|X)[0-9a-fA-F]+)|(([0-9]+(\.[0-9]+)?))(e[0-9]+(\.[0-9]+)?)?)\b</string>
 			<key>name</key>
 			<string>constant.numeric.tsx</string>
 		</dict>

--- a/tests/baselines/Issue110.txt
+++ b/tests/baselines/Issue110.txt
@@ -3,4 +3,13 @@
 [3, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
 [4, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
 [5, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
-[8, 1]: source.ts comment.block.ts 
+[6, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[7, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[8, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[9, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[10, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[11, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[12, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[13, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[14, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[17, 1]: source.ts comment.block.ts 

--- a/tests/baselines/Issue110.txt
+++ b/tests/baselines/Issue110.txt
@@ -1,0 +1,6 @@
+[1, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[2, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[3, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[4, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[5, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[8, 1]: source.ts comment.block.ts 

--- a/tests/baselines/Issue110.txt
+++ b/tests/baselines/Issue110.txt
@@ -12,4 +12,7 @@
 [12, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
 [13, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
 [14, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
-[17, 1]: source.ts comment.block.ts 
+[15, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[16, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[16, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.ts 
+[19, 1]: source.ts comment.block.ts 

--- a/tests/cases/Issue110.ts
+++ b/tests/cases/Issue110.ts
@@ -12,6 +12,8 @@ let number11 = ^^12E-10
 let number12 = ^^13.4e-14.2
 let number13 = ^^14.12
 let number14 = ^^10.2E+4
+let number6 = ^^5.00567789e+2
+let i = ^^1, j = ^^1e3
 
 /*
 ^^

--- a/tests/cases/Issue110.ts
+++ b/tests/cases/Issue110.ts
@@ -3,6 +3,15 @@ let number2 = ^^14e15
 let number3 = ^^10.42e41.5 
 let number4 = ^^4
 let number5 = ^^51.4
+let number6 = ^^12.4E10.2
+let number7 = ^^14.6e+10
+let number8 = ^^12E4
+let number9 = ^^10e10
+let number10 = ^^14e14.5
+let number11 = ^^12E-10
+let number12 = ^^13.4e-14.2
+let number13 = ^^14.12
+let number14 = ^^10.2E+4
 
 /*
 ^^

--- a/tests/cases/Issue110.ts
+++ b/tests/cases/Issue110.ts
@@ -1,0 +1,10 @@
+let number1 = ^^0x100   
+let number2 = ^^14e15
+let number3 = ^^10.42e41.5 
+let number4 = ^^4
+let number5 = ^^51.4
+
+/*
+^^
+  Testing comments
+*/


### PR DESCRIPTION
Solving Issue #110, numbers in exponential notation not colored