### PR TITLE
Parse longer expressions first, to help ligatures in Editors

### DIFF
--- a/FindRefs.YAML-tmLanguage
+++ b/FindRefs.YAML-tmLanguage
@@ -9,7 +9,7 @@ patterns:
   - include: '#footer'
   - include: '#reference'
   - include: '#line-with-match'
-  
+
 repository:
   filename:
     match: ^([^ ].*:)$
@@ -39,7 +39,7 @@ repository:
   # is for single-line referenes into TypeScript files)
   var-expr:
     name: meta.var.expr.ts
-    begin: (?<!\()\s*\b(var|let|const(?!\s+enum))\s+([a-zA-Z_$][\w$]*) 
+    begin: (?<!\()\s*\b(var|let|const(?!\s+enum))\s+([a-zA-Z_$][\w$]*)
     beginCaptures:
       '1': { name: storage.type.ts }
       '2': { name: variable.ts }
@@ -51,12 +51,12 @@ repository:
     name: keyword.control.ts
     match: \b(break|catch|continue|declare|do|else|finally|for|if|return|switch|throw|try|while)\b
 
-  switch-case: 
+  switch-case:
     name: case.expr.ts
     begin: '\b(case|default)\b'
     beginCaptures:
       '1': { name: keyword.control.ts }
-    end: ':'  
+    end: ':'
     patterns:
     - include: '#expression'
 
@@ -107,7 +107,7 @@ repository:
     match: (?:\b(extends|implements)\b|,)(?:\s+([a-zA-Z_$][.\w$]*))
     captures:
        '1': { name: storage.modifier.ts }
-       '2': { name: storage.type.ts } 
+       '2': { name: storage.type.ts }
 
   object-body:
     name: meta.object.body.ts
@@ -186,7 +186,7 @@ repository:
     match: ([a-zA-Z_$][\w$]*)(?=\:)
     captures:
       '1': { name: variable.parameter.ts}
-      
+
   function-declaration:
     name: meta.function.ts
     begin: \b(function)\b(?:\s+([a-zA-Z_$][\w$]*))?\s*
@@ -295,7 +295,7 @@ repository:
   type-parameters:
     name: meta.type.parameters.ts
     begin: '<'
-    end: '$|(?=var|type|function|class|interface)|>'  
+    end: '$|(?=var|type|function|class|interface)|>'
     patterns:
     - name: keyword.other.ts
       match: '\b(extends)\b'
@@ -308,7 +308,7 @@ repository:
       '1': { name: keyword.operator.ts }
     end: $|(?=[,);=])
     patterns:
-      - include: '#expression'  
+      - include: '#expression'
 
   expression:
     name: meta.expression.ts
@@ -347,14 +347,14 @@ repository:
     captures:
        '1': { name: storage.type.ts }
        '2': { name: storage.type.ts }
-  
+
   new-expr:
     name: new.expr.ts
     match: '\b(new)\b\s*([a-zA-Z_$][.\w$]*)'
     captures:
        '1': { name: keyword.operator.ts }
        '2': { name: storage.type.ts }
-     
+
   # TODO: object members with quoted or numric lhs
   object-member:
     name: meta.object.member.ts
@@ -373,15 +373,15 @@ repository:
 
   relational-operator:
     name: keyword.operator.ts
-    match: ===|==|=|!=|!==|<=|>=|<>|<|>
+    match: ===|!==|==|!=|<=|>=|<>|=|<|>
 
   assignment-operator:
     name: keyword.operator.ts
-    match: <<=|>>=|>>>=|\*=|(?<!\()/=|%=|\+=|\-=|&=|\^=
+    match: <<=|>>>=|>>=|\*=|(?<!\()/=|%=|\+=|\-=|&=|\^=
 
   logic-operator:
     name: keyword.operator.ts
-    match: \!|&|~|\||&&|\|\|
+    match: \!|&&|&|~|\|\||\|
 
   storage-keyword:
     name: storage.type.ts
@@ -503,7 +503,7 @@ repository:
     - include: '#expression'
 
   numeric-literal:
-    name: constant.numeric.ts 
+    name: constant.numeric.ts
     match: \b((0(x|X)[0-9a-fA-F]+)|([0-9]+(\.[0-9]+)?))\b
 
   boolean-literal:
@@ -521,7 +521,7 @@ repository:
   access-modifier:
     name: storage.modifier.ts
     match: \b(public|protected|private)\b
-    
+
   static-modifier:
     name: keyword.other.ts
     match: \b(static)\b
@@ -529,8 +529,3 @@ repository:
   property-accessor:
     name: storage.type.property.ts
     match: \b(get|set)\b
-
-
-
-    
-  

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -157,7 +157,7 @@ repository:
     begin: '\b(?:(abstract)\s+)?\b(?:(public|private|protected)\s+)?\b(?:(async)\s+)?(?:(get|set)\s+)?(?:(new)|(?:\b(constructor)\b)|(?:([a-zA-Z_$][\.\w$]*)\s*(\??)))?\s*(?=\(|\<)'
     beginCaptures:
       '1': { name: storage.modifier.ts } # captures keyword (abstract)
-      '2': { name: storage.modifier.ts } # captures keyword (public or private or protected) 
+      '2': { name: storage.modifier.ts } # captures keyword (public or private or protected)
       '3': { name: storage.modifier.ts } # captures keyword (async)
       '4': { name: storage.type.property.ts } # captures keyword (get|set)
       '5': { name: keyword.operator.ts } # captures keyword (new)
@@ -178,7 +178,7 @@ repository:
     match: '\b(?:(abstract)\s+)?\b(?:(public|private|protected)\s+)?\b(?:(async)\s+)?(?:(get|set)\s+)?(?:(new)|(?:\b(constructor)\b)|(?:([a-zA-Z_$][\.\w$]*)\s*(\??)))?\s*(?=\(|\<)'
     captures:
       '1': { name: storage.modifier.ts } # captures keyword (abstract)
-      '2': { name: storage.modifier.ts } # captures keyword (public or private or protected) 
+      '2': { name: storage.modifier.ts } # captures keyword (public or private or protected)
       '3': { name: storage.modifier.ts } # captures keyword (async)
       '4': { name: storage.type.property.ts } # captures keyword (get|set)
       '5': { name: keyword.operator.ts } # captures keyword (new)
@@ -512,15 +512,15 @@ repository:
 
   relational-operator:
     name: keyword.operator.comparison.ts
-    match: ===|==|=|!=|!==|<=|>=|<>|<|>
+    match: ===|!==|==|!=|<=|>=|<>|=|<|>
 
   assignment-operator:
     name: keyword.operator.assignment.ts
-    match: <<=|>>=|>>>=|\*=|(?<!\()/=|%=|\+=|\-=|&=|\^=
+    match: <<=|>>>=|>>=|\*=|(?<!\()/=|%=|\+=|\-=|&=|\^=
 
   logic-operator:
     name: keyword.operator.arithmetic.ts
-    match: \!|&|~|\^|\||&&|\|\|
+    match: \!|&&|&|~|\^|\|\||\|
 
   storage-keyword:
     name: storage.type.ts

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -66,7 +66,7 @@
 		<key>assignment-operator</key>
 		<dict>
 			<key>match</key>
-			<string>&lt;&lt;=|&gt;&gt;=|&gt;&gt;&gt;=|\*=|(?&lt;!\()/=|%=|\+=|\-=|&amp;=|\^=</string>
+			<string>&lt;&lt;=|&gt;&gt;&gt;=|&gt;&gt;=|\*=|(?&lt;!\()/=|%=|\+=|\-=|&amp;=|\^=</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.ts</string>
 		</dict>
@@ -730,7 +730,7 @@
 		<key>logic-operator</key>
 		<dict>
 			<key>match</key>
-			<string>\!|&amp;|~|\^|\||&amp;&amp;|\|\|</string>
+			<string>\!|&amp;&amp;|&amp;|~|\^|\|\||\|</string>
 			<key>name</key>
 			<string>keyword.operator.arithmetic.ts</string>
 		</dict>
@@ -1247,7 +1247,7 @@
 		<key>relational-operator</key>
 		<dict>
 			<key>match</key>
-			<string>===|==|=|!=|!==|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
+			<string>===|!==|==|!=|&lt;=|&gt;=|&lt;&gt;|=|&lt;|&gt;</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.ts</string>
 		</dict>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -159,7 +159,7 @@ repository:
     begin: '\b(?:(abstract)\s+)?\b(?:(public|private|protected)\s+)?\b(?:(async)\s+)?(?:(get|set)\s+)?(?:(new)|(?:\b(constructor)\b)|(?:([a-zA-Z_$][\.\w$]*)\s*(\??)))?\s*(?=\(|\<)'
     beginCaptures:
       '1': { name: storage.modifier.tsx } # captures keyword (abstract)
-      '2': { name: storage.modifier.tsx } # captures keyword (public or private or protected) 
+      '2': { name: storage.modifier.tsx } # captures keyword (public or private or protected)
       '3': { name: storage.modifier.tsx } # captures keyword (async)
       '4': { name: storage.type.property.tsx } # captures keyword (get|set)
       '5': { name: keyword.operator.tsx } # captures keyword (new)
@@ -180,7 +180,7 @@ repository:
     match: '\b(?:(abstract)\s+)?\b(?:(public|private|protected)\s+)?\b(?:(async)\s+)?(?:(get|set)\s+)?(?:(new)|(?:\b(constructor)\b)|(?:([a-zA-Z_$][\.\w$]*)\s*(\??)))?\s*(?=\(|\<)'
     captures:
       '1': { name: storage.modifier.tsx } # captures keyword (abstract)
-      '2': { name: storage.modifier.tsx } # captures keyword (public or private or protected) 
+      '2': { name: storage.modifier.tsx } # captures keyword (public or private or protected)
       '3': { name: storage.modifier.tsx } # captures keyword (async)
       '4': { name: storage.type.property.tsx } # captures keyword (get|set)
       '5': { name: keyword.operator.tsx } # captures keyword (new)
@@ -501,15 +501,15 @@ repository:
   relational-operator:
 
     name: keyword.operator.comparison.tsx
-    match: ===|==|=|!=|!==|<=|>=|<>|<|>
+    match: ===|!==|==|!=|<=|>=|<>|=|<|>
 
   assignment-operator:
     name: keyword.operator.assignment.tsx
-    match: <<=|>>=|>>>=|\*=|(?<!\()/=|%=|\+=|\-=|&=|\^=
+    match: <<=|>>>=|>>=|\*=|(?<!\()/=|%=|\+=|\-=|&=|\^=
 
   logic-operator:
     name: keyword.operator.arithmetic.tsx
-    match: \!|&|~|\^|\||&&|\|\|
+    match: \!|&&|&|~|\^|\|\||\|
 
   storage-keyword:
     name: storage.type.tsx

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -66,7 +66,7 @@
 		<key>assignment-operator</key>
 		<dict>
 			<key>match</key>
-			<string>&lt;&lt;=|&gt;&gt;=|&gt;&gt;&gt;=|\*=|(?&lt;!\()/=|%=|\+=|\-=|&amp;=|\^=</string>
+			<string>&lt;&lt;=|&gt;&gt;&gt;=|&gt;&gt;=|\*=|(?&lt;!\()/=|%=|\+=|\-=|&amp;=|\^=</string>
 			<key>name</key>
 			<string>keyword.operator.assignment.tsx</string>
 		</dict>
@@ -1096,7 +1096,7 @@
 		<key>logic-operator</key>
 		<dict>
 			<key>match</key>
-			<string>\!|&amp;|~|\^|\||&amp;&amp;|\|\|</string>
+			<string>\!|&amp;&amp;|&amp;|~|\^|\|\||\|</string>
 			<key>name</key>
 			<string>keyword.operator.arithmetic.tsx</string>
 		</dict>
@@ -1613,7 +1613,7 @@
 		<key>relational-operator</key>
 		<dict>
 			<key>match</key>
-			<string>===|==|=|!=|!==|&lt;=|&gt;=|&lt;&gt;|&lt;|&gt;</string>
+			<string>===|!==|==|!=|&lt;=|&gt;=|&lt;&gt;|=|&lt;|&gt;</string>
 			<key>name</key>
 			<string>keyword.operator.comparison.tsx</string>
 		</dict>


### PR DESCRIPTION
This helps with this issue in atom-typescript : https://github.com/TypeStrong/atom-typescript/issues/851
which I first wanted to fix here : https://github.com/TypeStrong/atom-typescript/pull/926