### PR TITLE
add failing tests for #81

### DIFF
--- a/tests/baselines/Issue81.txt
+++ b/tests/baselines/Issue81.txt
@@ -1,0 +1,4 @@
+[1, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts 
+[1, 18]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.double.ts 
+[1, 24]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts 
+[1, 26]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.double.ts 

--- a/tests/cases/Issue81.ts
+++ b/tests/cases/Issue81.ts
@@ -1,0 +1,1 @@
+const a = true ^^? ^^"foo" ^^: ^^"bar";


### PR DESCRIPTION
I added a test case and baseline for #81. It has something to do with [this](https://github.com/Microsoft/TypeScript-TmLanguage/blob/master/TypeScript.YAML-tmLanguage#L273-L281) block. If I temporarily change the begin regexp to something like `a`, this specific test passes.

I noticed PR #129. Not sure if a separate repository is necessary. Just wanted to share this, maybe someone else has an idea.

// @Tyriar 