### PR TITLE
Allow method return types to end with a digit

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -307,7 +307,7 @@ repository:
   type-annotation:
     name: meta.type.annotation.ts
     begin: ":"
-    end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[a-zA-Z_$])\s*(?=\{)
+    end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[a-zA-Z0-9_$])\s*(?=\{)
     patterns:
     - include: '#expression-operator'
     - include: '#type'

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1604,7 +1604,7 @@
 			<key>begin</key>
 			<string>:</string>
 			<key>end</key>
-			<string>(?=$|[,);\}\]]|//)|(?==[^&gt;])|(?&lt;=[\}&gt;\]\)]|[a-zA-Z_$])\s*(?=\{)</string>
+			<string>(?=$|[,);\}\]]|//)|(?==[^&gt;])|(?&lt;=[\}&gt;\]\)]|[a-zA-Z0-9_$])\s*(?=\{)</string>
 			<key>name</key>
 			<string>meta.type.annotation.ts</string>
 			<key>patterns</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -309,7 +309,7 @@ repository:
   type-annotation:
     name: meta.type.annotation.tsx
     begin: ":"
-    end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[a-zA-Z_$])\s*(?=\{)
+    end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[a-zA-Z0-9_$])\s*(?=\{)
     patterns:
     - include: '#expression-operator'
     - include: '#type'

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1970,7 +1970,7 @@
 			<key>begin</key>
 			<string>:</string>
 			<key>end</key>
-			<string>(?=$|[,);\}\]]|//)|(?==[^&gt;])|(?&lt;=[\}&gt;\]\)]|[a-zA-Z_$])\s*(?=\{)</string>
+			<string>(?=$|[,);\}\]]|//)|(?==[^&gt;])|(?&lt;=[\}&gt;\]\)]|[a-zA-Z0-9_$])\s*(?=\{)</string>
 			<key>name</key>
 			<string>meta.type.annotation.tsx</string>
 			<key>patterns</key>

--- a/tests/baselines/FunctionMethodReturnTypes.txt
+++ b/tests/baselines/FunctionMethodReturnTypes.txt
@@ -76,3 +76,6 @@
 [30, 5]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts storage.modifier.ts 
 [30, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts entity.name.function.ts 
 [30, 69]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts keyword.control.ts 
+[31, 5]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts storage.modifier.ts 
+[31, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts entity.name.function.ts 
+[31, 55]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts keyword.control.ts 

--- a/tests/baselines/FunctionMethodReturnTypes.txt
+++ b/tests/baselines/FunctionMethodReturnTypes.txt
@@ -79,3 +79,5 @@
 [31, 5]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts storage.modifier.ts 
 [31, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts entity.name.function.ts 
 [31, 55]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts keyword.control.ts 
+[31, 62]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts constant.numeric.ts 
+[31, 66]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.brace.curly.ts 

--- a/tests/cases/FunctionMethodReturnTypes.ts
+++ b/tests/cases/FunctionMethodReturnTypes.ts
@@ -28,7 +28,7 @@ class TestClass {
     ^^public ^^testMethodReturnType11(): number | string { ^^return 1 }
     ^^public ^^testMethodReturnType12(): number | string [] { ^^return }
     ^^public ^^testMethodReturnType13(): [number, number] | string [] { ^^return [""] }
-    ^^public ^^testMethodReturnType14(): EndsWithDigit1 { ^^return 123 }
+    ^^public ^^testMethodReturnType14(): EndsWithDigit1 { ^^return ^^123 ^^}
 }
 
 type EndsWithDigit1 = number;

--- a/tests/cases/FunctionMethodReturnTypes.ts
+++ b/tests/cases/FunctionMethodReturnTypes.ts
@@ -28,4 +28,7 @@ class TestClass {
     ^^public ^^testMethodReturnType11(): number | string { ^^return 1 }
     ^^public ^^testMethodReturnType12(): number | string [] { ^^return }
     ^^public ^^testMethodReturnType13(): [number, number] | string [] { ^^return [""] }
+    ^^public ^^testMethodReturnType14(): EndsWithDigit1 { ^^return 123 }
 }
+
+type EndsWithDigit1 = number;


### PR DESCRIPTION
Syntax coloring fails if method return type ends with a digit. This pull request allows digits to be the last character in `type-annotation.end` regular expression.

Fixes https://github.com/Microsoft/TypeScript/issues/9444 and should be in line with the to-be-added numeric literal types https://github.com/Microsoft/TypeScript/pull/9407.