### PR TITLE
[added]: html syntax highlight in template strings

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -618,6 +618,7 @@ repository:
     end: (?=(\$\{|`))
     patterns:
     - include: '#string-character-escape'
+    - include: 'text.html.basic'
 
   string-character-escape:
     name: constant.character.escape

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1414,6 +1414,10 @@
 					<key>include</key>
 					<string>#string-character-escape</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>text.html.basic</string>
+				</dict>
 			</array>
 		</dict>
 		<key>template-substitution-element</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -607,6 +607,7 @@ repository:
     end: (?=(\$\{|`))
     patterns:
     - include: '#string-character-escape'
+    - include: 'text.html.basic'
 
   string-character-escape:
     name: constant.character.escape

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1780,6 +1780,10 @@
 					<key>include</key>
 					<string>#string-character-escape</string>
 				</dict>
+				<dict>
+					<key>include</key>
+					<string>text.html.basic</string>
+				</dict>
 			</array>
 		</dict>
 		<key>template-substitution-element</key>


### PR DESCRIPTION
hi. 
These updated add support for html syntax in template strings. 
This feature support is useful for several use cases: 

1. if you're developing with Angular 2 using Typescript - it is easier to see a component's template inside a ts file (as shown in the screenshot below). 
2. There are use cases where an html template is constructed with template strings and template variables - it is very helpful to see the markup inside a ts file in this case as well. 

As a reference: 
I added html support by following [this thread](https://forum.sublimetext.com/t/javascript-es6-template-literals-syntax-for-html/18242/2) 

<img width="686" alt="html" src="https://cloud.githubusercontent.com/assets/878660/17114719/c972c3b2-52b8-11e6-9a42-0c5e81210312.png">
