### PR TITLE
Allowed digits at the end of method return type

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -37,13 +37,13 @@ repository:
     end: (?=$|[;,])
     patterns:
     - include: '#ternary-operator'
-    - include: '#expression-type' 
+    - include: '#expression-type'
 
   ternary-operator:
     begin: (\?)
     end: (:)
     patterns:
-    - include: '#expression-type' 
+    - include: '#expression-type'
 
   expression-type:
     name: meta.expression.ts
@@ -63,7 +63,7 @@ repository:
     - include: '#logic-operator'
     - include: '#assignment-operator'
     - include: '#type-primitive'
-    - include: '#function-call' 
+    - include: '#function-call'
 
   control-statement:
     name: keyword.control.ts
@@ -307,7 +307,7 @@ repository:
   type-annotation:
     name: meta.type.annotation.ts
     begin: ":"
-    end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[a-zA-Z_$])\s*(?=\{)
+    end: (?=$|[,);\}\]]|//)|(?==[^>])|(?<=[\}>\]\)]|[\w$])\s*(?=\{)
     patterns:
     - include: '#expression-operator'
     - include: '#type'

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1604,7 +1604,7 @@
 			<key>begin</key>
 			<string>:</string>
 			<key>end</key>
-			<string>(?=$|[,);\}\]]|//)|(?==[^&gt;])|(?&lt;=[\}&gt;\]\)]|[a-zA-Z_$])\s*(?=\{)</string>
+			<string>(?=$|[,);\}\]]|//)|(?==[^&gt;])|(?&lt;=[\}&gt;\]\)]|[\w$])\s*(?=\{)</string>
 			<key>name</key>
 			<string>meta.type.annotation.ts</string>
 			<key>patterns</key>

--- a/tests/baselines/Issue188.txt
+++ b/tests/baselines/Issue188.txt
@@ -1,0 +1,8 @@
+[9, 22]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.type.annotation.ts meta.type.name.ts 
+[9, 29]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.brace.curly.ts 
+[12, 5]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts keyword.control.ts 
+[12, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts constant.language.this.ts 
+[24, 22]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.type.annotation.ts meta.type.name.ts 
+[24, 30]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts meta.brace.curly.ts 
+[27, 5]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts keyword.control.ts 
+[27, 12]: source.ts meta.declaration.object.ts meta.object.body.ts meta.method.declaration.ts meta.decl.block.ts constant.language.this.ts 

--- a/tests/cases/Issue188.ts
+++ b/tests/cases/Issue188.ts
@@ -1,0 +1,29 @@
+class Matrix {
+
+  public elements;
+
+  constructor() {
+    this.elements = new Float32Array([1]);
+  }
+
+  set(m11: number) : ^^Matrix ^^{
+    this.elements[0] = m11;
+
+    ^^return ^^this;
+  }
+}
+
+class Matrix1 {
+
+  public elements;
+
+  constructor() {
+    this.elements = new Float32Array([1]);
+  }
+
+  set(m11: number) : ^^Matrix1 ^^{
+    this.elements[0] = m11;
+
+    ^^return ^^this;
+  }
+}


### PR DESCRIPTION
Fixes #153 - includes tests. The regex for `type-annotation` was looking for `[a-zA-Z_$]` (the regex used for the _first_ character) as the pattern for the last character rather than `[\w$]`. There are a few regexes around that allows `[.\w$]` for the last character of a type name but as far as I can tell, type names can't end with a dot so I've not included this.

I have a plugin that removes whitespace at the end of lines so there are some rogue changes in here that I missed, which can be removed if required.