### PR TITLE
Add primitive types null, true, and false

### DIFF
--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1850,7 +1850,7 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b(string|number|boolean|symbol|any|void)\b</string>
+			<string>\b(string|number|boolean|symbol|any|void|null|true|false)\b</string>
 			<key>name</key>
 			<string>meta.type.primitive.ts</string>
 		</dict>


### PR DESCRIPTION
Starting with TypeScript 2, we can use all kinds of literal types. These three are very common literal types which also happen to be reserved words, so I guess it makes sense to handle them in a special way.

Ultimately, it might make sense to expand the syntax structure for literal types a bit but for now, this is a quick fix.