### PR TITLE
Fix the end expression regex for return type

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -690,7 +690,7 @@ repository:
     begin: '(?<=\))\s*(:)'
     beginCaptures:
       '1': { name: keyword.operator.type.annotation.ts }
-    end: (?<!:)((?=$)|(?=\{|;|//))
+    end: (?<!:)((?=$)|(?=\{|;|//|\}))
     patterns:
     - include: '#comment'
     # Handle returning of object type specifically here so as to not confuse it with the start of function block

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -63,10 +63,10 @@ repository:
       end: (?=$|[;,}]|(\s+(of|in)\s+))
       patterns:
       - include: '#variable-initializer'
-      - begin: \G
-        end: (?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))
+      - begin: (?<=\{)
+        end: (?=$|[;,=}]|(\s+(of|in)\s+))
         patterns:
-        - begin: \G
+        - begin: (?<=\{)
           end: \}
           endCaptures:
             '0': { name: punctuation.definition.binding-pattern.object.ts }
@@ -81,10 +81,10 @@ repository:
       end: (?=$|[;,}]|(\s+(of|in)\s+))
       patterns:
       - include: '#variable-initializer'
-      - begin: \G
-        end: (?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))
+      - begin: (?<=\[)
+        end: (?=$|[;,=}]|(\s+(of|in)\s+))
         patterns:
-        - begin: \G
+        - begin: (?<=\[)
           end: \]
           endCaptures:
             '0': { name: punctuation.definition.binding-pattern.array.ts }

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -1312,7 +1312,7 @@ repository:
       end: (?=,|\})
       patterns:
       - name: meta.object-literal.key.ts
-        begin: \G(?<!:)
+        begin: (?=(?:(?:\'[^']*\')|(?:\"[^"]*\")|(?:\[[^\]]*\]))\s*:)
         end: ':'
         endCaptures:
           '0': { name: punctuation.separator.key-value.ts }

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -3642,7 +3642,7 @@
                 <key>name</key>
                 <string>meta.object-literal.key.ts</string>
                 <key>begin</key>
-                <string>\G(?&lt;!:)</string>
+                <string>(?=(?:(?:\'[^']*\')|(?:\"[^"]*\")|(?:\[[^\]]*\]))\s*:)</string>
                 <key>end</key>
                 <string>:</string>
                 <key>endCaptures</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -2245,7 +2245,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?&lt;!:)((?=$)|(?=\{|;|//))</string>
+        <string>(?&lt;!:)((?=$)|(?=\{|;|//|\}))</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -192,14 +192,14 @@
               </dict>
               <dict>
                 <key>begin</key>
-                <string>\G</string>
+                <string>(?&lt;=\{)</string>
                 <key>end</key>
-                <string>(?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))</string>
+                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
                 <key>patterns</key>
                 <array>
                   <dict>
                     <key>begin</key>
-                    <string>\G</string>
+                    <string>(?&lt;=\{)</string>
                     <key>end</key>
                     <string>\}</string>
                     <key>endCaptures</key>
@@ -253,14 +253,14 @@
               </dict>
               <dict>
                 <key>begin</key>
-                <string>\G</string>
+                <string>(?&lt;=\[)</string>
                 <key>end</key>
-                <string>(?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))</string>
+                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
                 <key>patterns</key>
                 <array>
                   <dict>
                     <key>begin</key>
-                    <string>\G</string>
+                    <string>(?&lt;=\[)</string>
                     <key>end</key>
                     <string>\]</string>
                     <key>endCaptures</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -3624,7 +3624,7 @@
                 <key>name</key>
                 <string>meta.object-literal.key.tsx</string>
                 <key>begin</key>
-                <string>\G(?&lt;!:)</string>
+                <string>(?=(?:(?:\'[^']*\')|(?:\"[^"]*\")|(?:\[[^\]]*\]))\s*:)</string>
                 <key>end</key>
                 <string>:</string>
                 <key>endCaptures</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -2249,7 +2249,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?&lt;!:)((?=$)|(?=\{|;|//))</string>
+        <string>(?&lt;!:)((?=$)|(?=\{|;|//|\}))</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -192,14 +192,14 @@
               </dict>
               <dict>
                 <key>begin</key>
-                <string>\G</string>
+                <string>(?&lt;=\{)</string>
                 <key>end</key>
-                <string>(?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))</string>
+                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
                 <key>patterns</key>
                 <array>
                   <dict>
                     <key>begin</key>
-                    <string>\G</string>
+                    <string>(?&lt;=\{)</string>
                     <key>end</key>
                     <string>\}</string>
                     <key>endCaptures</key>
@@ -253,14 +253,14 @@
               </dict>
               <dict>
                 <key>begin</key>
-                <string>\G</string>
+                <string>(?&lt;=\[)</string>
                 <key>end</key>
-                <string>(?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))</string>
+                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
                 <key>patterns</key>
                 <array>
                   <dict>
                     <key>begin</key>
-                    <string>\G</string>
+                    <string>(?&lt;=\[)</string>
                     <key>end</key>
                     <string>\]</string>
                     <key>endCaptures</key>

--- a/tests/baselines/binder.baseline.txt
+++ b/tests/baselines/binder.baseline.txt
@@ -1,0 +1,204 @@
+original file
+-----------------------------------
+    function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
+        let Symbol: { new (flags: SymbolFlags, name: string): Symbol };
+        let classifiableNames: Map<string>;
+
+        const unreachableFlow: FlowNode = { flags: FlowFlags.Unreachable };
+    }
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>    function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
+ ^^^^
+ source.ts
+     ^^^^^^^^
+     source.ts meta.function.ts storage.type.function.ts
+             ^
+             source.ts meta.function.ts
+              ^^^^^^^^^^^^
+              source.ts meta.function.ts entity.name.function.ts
+                          ^
+                          source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                           ^
+                           source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                            ^
+                            source.ts meta.function.ts meta.return.type.ts keyword.operator.type.annotation.ts
+                             ^
+                             source.ts meta.function.ts meta.return.type.ts meta.type.function.ts
+                              ^
+                              source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                               ^^^^
+                               source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
+                                   ^
+                                   source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                    ^
+                                    source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
+                                     ^^^^^^^^^^
+                                     source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                                               ^
+                                               source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts punctuation.separator.parameter.ts
+                                                ^
+                                                source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts
+                                                 ^^^^^^^
+                                                 source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
+                                                        ^
+                                                        source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                                         ^
+                                                         source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
+                                                          ^^^^^^^^^^^^^^^
+                                                          source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                                                                         ^
+                                                                         source.ts meta.function.ts meta.return.type.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                                                          ^
+                                                                          source.ts meta.function.ts meta.return.type.ts
+                                                                           ^^
+                                                                           source.ts meta.function.ts meta.return.type.ts meta.type.function.return.ts storage.type.function.arrow.ts
+                                                                             ^
+                                                                             source.ts meta.function.ts meta.return.type.ts meta.type.function.return.ts
+                                                                              ^^^^
+                                                                              source.ts meta.function.ts meta.return.type.ts meta.type.function.return.ts support.type.primitive.ts
+                                                                                  ^
+                                                                                  source.ts meta.function.ts meta.return.type.ts meta.type.function.return.ts
+                                                                                   ^
+                                                                                   source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                                                                                    ^^
+                                                                                    source.ts meta.function.ts meta.block.ts
+>        let Symbol: { new (flags: SymbolFlags, name: string): Symbol };
+ ^^^^^^^^
+ source.ts meta.function.ts meta.block.ts
+         ^^^
+         source.ts meta.function.ts meta.block.ts meta.var.expr.ts storage.type.ts
+            ^
+            source.ts meta.function.ts meta.block.ts meta.var.expr.ts
+             ^^^^^^
+             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                   ^
+                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                    ^
+                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
+                     ^
+                     source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts punctuation.definition.block.ts
+                      ^
+                      source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts
+                       ^^^
+                       source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts keyword.operator.new.ts
+                          ^
+                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts
+                           ^
+                           source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                            ^^^^^
+                            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                                 ^
+                                 source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                  ^
+                                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                                   ^^^^^^^^^^^
+                                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                                              ^
+                                              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts punctuation.separator.parameter.ts
+                                               ^
+                                               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts
+                                                ^^^^
+                                                source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                                                    ^
+                                                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                                     ^
+                                                     source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                                                      ^^^^^^
+                                                      source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                                                            ^
+                                                            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                                             ^
+                                                             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.return.type.ts keyword.operator.type.annotation.ts
+                                                              ^
+                                                              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.return.type.ts
+                                                               ^^^^^^
+                                                               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.return.type.ts entity.name.type.ts
+                                                                     ^
+                                                                     source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.method.declaration.ts meta.return.type.ts
+                                                                      ^
+                                                                      source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts punctuation.definition.block.ts
+                                                                       ^
+                                                                       source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
+                                                                        ^^
+                                                                        source.ts meta.function.ts meta.block.ts
+>        let classifiableNames: Map<string>;
+ ^^^^^^^^
+ source.ts meta.function.ts meta.block.ts
+         ^^^
+         source.ts meta.function.ts meta.block.ts meta.var.expr.ts storage.type.ts
+            ^
+            source.ts meta.function.ts meta.block.ts meta.var.expr.ts
+             ^^^^^^^^^^^^^^^^^
+             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                              ^
+                              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                               ^
+                               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
+                                ^^^
+                                source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts entity.name.type.ts
+                                   ^
+                                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                                    ^^^^^^
+                                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.type.parameters.ts support.type.primitive.ts
+                                          ^
+                                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                           ^
+                                           source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
+                                            ^^
+                                            source.ts meta.function.ts meta.block.ts
+>
+ ^^
+ source.ts meta.function.ts meta.block.ts
+>        const unreachableFlow: FlowNode = { flags: FlowFlags.Unreachable };
+ ^^^^^^^^
+ source.ts meta.function.ts meta.block.ts
+         ^^^^^
+         source.ts meta.function.ts meta.block.ts meta.var.expr.ts storage.type.ts
+              ^
+              source.ts meta.function.ts meta.block.ts meta.var.expr.ts
+               ^^^^^^^^^^^^^^^
+               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                              ^
+                              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                               ^
+                               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
+                                ^^^^^^^^
+                                source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts entity.name.type.ts
+                                        ^
+                                        source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
+                                         ^
+                                         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                          ^
+                                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                           ^
+                                           source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                            ^
+                                            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                             ^^^^^
+                                             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts entity.name.type.attribute-name.ts
+                                                  ^
+                                                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                                                   ^
+                                                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                                                    ^^^^^^^^^
+                                                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
+                                                             ^
+                                                             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
+                                                              ^^^^^^^^^^^
+                                                              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
+                                                                         ^
+                                                                         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                                                                          ^
+                                                                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                                                           ^
+                                                                           source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
+                                                                            ^^
+                                                                            source.ts meta.function.ts meta.block.ts
+>    }
+ ^^^^
+ source.ts meta.function.ts meta.block.ts
+     ^
+     source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts

--- a/tests/cases/binder.ts
+++ b/tests/cases/binder.ts
@@ -1,0 +1,6 @@
+    function createBinder(): (file: SourceFile, options: CompilerOptions) => void {
+        let Symbol: { new (flags: SymbolFlags, name: string): Symbol };
+        let classifiableNames: Map<string>;
+
+        const unreachableFlow: FlowNode = { flags: FlowFlags.Unreachable };
+    }


### PR DESCRIPTION
It could end at \} if its last object type member without ';'