### PR TITLE
Few bug fixes

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -482,7 +482,7 @@ repository:
 
   method-declaration:
     name: meta.method.declaration.ts
-    begin: (?<!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
+    begin: (?<!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
     beginCaptures:
       '1': { name: storage.modifier.ts } # captures keyword (abstract)
       '2': { name: storage.modifier.ts } # captures keyword (public or private or protected)
@@ -503,7 +503,7 @@ repository:
 
   method-overload-declaration:
     name: meta.method.overload.declaration.ts
-    begin: (?<!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
+    begin: (?<!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
     beginCaptures:
       '1': { name: storage.modifier.ts } # captures keyword (abstract)
       '2': { name: storage.modifier.ts } # captures keyword (public or private or protected)

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1573,7 +1573,7 @@
         <key>name</key>
         <string>meta.method.declaration.ts</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1651,7 +1651,7 @@
         <key>name</key>
         <string>meta.method.overload.declaration.ts</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -199,7 +199,6 @@ repository:
     - include: '#jsx-entities'
 
   jsx:
-    name: meta.jsx.tsx
     patterns:
     - include: '#jsx-tag-without-attributes'
     - include: '#jsx-tag-in-expression'

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -119,7 +119,7 @@ repository:
     patterns:
     - include: '#jsx-children'
 
-  jsx-tag:
+  jsx-tag-in-expression:
     # We need to differentiate between the relational '<' operator and the beginning of a tag using the surrounding context.
     begin: >-
       (?x)
@@ -137,8 +137,35 @@ repository:
       '3': { name: entity.name.tag.tsx }
       '4': { name: punctuation.definition.tag.end.tsx }
     patterns:
-    - name: meta.tag.tsx
-      begin: >-
+    - include: '#jsx-tag'
+
+  jsx-child-tag:
+    # Because this would be included from the jsx-children, this doesnt need to inspect surrounding context
+    begin: >-
+      (?x)
+        (?=(<)\s*
+        ([_$a-zA-Z][-$\w.]*(?<!\.|-))
+        (?=\s+(?!\?)|/?>))
+    end: (/>)|(?:(</)\s*([_$a-zA-Z][-$\w.]*(?<!\.|-))\s*(>))
+    endCaptures:
+      '0': { name: meta.tag.tsx }
+      '1': { name: punctuation.definition.tag.end.tsx }
+      '2': { name: punctuation.definition.tag.begin.tsx }
+      '3': { name: entity.name.tag.tsx }
+      '4': { name: punctuation.definition.tag.end.tsx }
+    patterns:
+    - include: '#jsx-tag'
+
+  jsx-tag:
+    name: meta.tag.tsx
+    begin: >-
+      (?x)
+        (?=(<)\s*
+        ([_$a-zA-Z][-$\w.]*(?<!\.|-))
+        (?=\s+(?!\?)|/?>))
+    end: (?=(/>)|(?:(</)\s*([_$a-zA-Z][-$\w.]*(?<!\.|-))\s*(>)))
+    patterns:
+    - begin: >-
         (?x)
           (<)\s*
           ([_$a-zA-Z][-$\w.]*(?<!\.|-))
@@ -146,21 +173,18 @@ repository:
       beginCaptures:
         '1': { name: punctuation.definition.tag.begin.tsx }
         '2': { name: entity.name.tag.tsx }
-      end: (?=(/>)|(?:(</)\s*([_$a-zA-Z][-$\w.]*(?<!\.|-))\s*(>)))
+      end: (?=[/]?>)
       patterns:
-      - begin: \G(?![/]?>)
-        end: (?=[/]?>)
-        patterns:
-        - include: '#comment'
-        - include: '#jsx-tag-attributes'
-        - include: '#jsx-tag-attributes-illegal'
-      - begin: (>)
-        beginCaptures:
-          '1': { name: punctuation.definition.tag.end.tsx }
-        end: (?=</)
-        contentName: meta.jsx.children.tsx
-        patterns:
-        - include: '#jsx-children'
+      - include: '#comment'
+      - include: '#jsx-tag-attributes'
+      - include: '#jsx-tag-attributes-illegal'
+    - begin: (>)
+      beginCaptures:
+        '1': { name: punctuation.definition.tag.end.tsx }
+      end: (?=</)
+      contentName: meta.jsx.children.tsx
+      patterns:
+      - include: '#jsx-children'
 
   jsx-tag-invalid:
     name: invalid.illegal.tag.incomplete.tsx
@@ -169,7 +193,7 @@ repository:
   jsx-children:
     patterns:
     - include: '#jsx-tag-without-attributes'
-    - include: '#jsx-tag'
+    - include: '#jsx-child-tag'
     - include: '#jsx-tag-invalid'
     - include: '#jsx-evaluated-code'
     - include: '#jsx-entities'
@@ -178,7 +202,7 @@ repository:
     name: meta.jsx.tsx
     patterns:
     - include: '#jsx-tag-without-attributes'
-    - include: '#jsx-tag'
+    - include: '#jsx-tag-in-expression'
     - include: '#jsx-tag-invalid'
 
 ...

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -89,13 +89,13 @@ repository:
       match: '&'
 
   jsx-evaluated-code:
-    name: meta.brace.curly.tsx
+    name: meta.embedded.expression.tsx
     begin: '{'
     end: '}'
     beginCaptures:
-      '0': {name: punctuation.definition.brace.curly.start.tsx}
+      '0': { name: punctuation.section.embedded.begin.tsx }
     endCaptures:
-      '0': {name: punctuation.definition.brace.curly.end.tsx}
+      '0': { name: punctuation.section.embedded.end.tsx }
     patterns:
     - include: '#expression'
 

--- a/TypeScriptReact.YAML-tmTheme
+++ b/TypeScriptReact.YAML-tmTheme
@@ -22,7 +22,7 @@ settings:
 - scope: meta.jsx.children.tsx, constant.character.entity.tsx, punctuation.definition.entity.tsx, invalid.illegal.bad-ampersand.tsx
   settings: { vsclassificationtype: xml literal - text }
 
-- scope: invalid.illegal.attribute.tsx, meta.brace.curly.tsx
+- scope: invalid.illegal.attribute.tsx, meta.embedded.expression.tsx
   settings: { vsclassificationtype: identifier }
 
 ...

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -5262,7 +5262,7 @@
           </dict>
         </array>
       </dict>
-      <key>jsx-tag</key>
+      <key>jsx-tag-in-expression</key>
       <dict>
         <key>begin</key>
         <string>(?x)
@@ -5305,8 +5305,70 @@
         <key>patterns</key>
         <array>
           <dict>
+            <key>include</key>
+            <string>#jsx-tag</string>
+          </dict>
+        </array>
+      </dict>
+      <key>jsx-child-tag</key>
+      <dict>
+        <key>begin</key>
+        <string>(?x)
+  (?=(&lt;)\s*
+  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
+  (?=\s+(?!\?)|/?&gt;))</string>
+        <key>end</key>
+        <string>(/&gt;)|(?:(&lt;/)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;))</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
             <key>name</key>
             <string>meta.tag.tsx</string>
+          </dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.tag.end.tsx</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.tag.begin.tsx</string>
+          </dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>entity.name.tag.tsx</string>
+          </dict>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.tag.end.tsx</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#jsx-tag</string>
+          </dict>
+        </array>
+      </dict>
+      <key>jsx-tag</key>
+      <dict>
+        <key>name</key>
+        <string>meta.tag.tsx</string>
+        <key>begin</key>
+        <string>(?x)
+  (?=(&lt;)\s*
+  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
+  (?=\s+(?!\?)|/?&gt;))</string>
+        <key>end</key>
+        <string>(?=(/&gt;)|(?:(&lt;/)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;)))</string>
+        <key>patterns</key>
+        <array>
+          <dict>
             <key>begin</key>
             <string>(?x)
   (&lt;)\s*
@@ -5326,52 +5388,43 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(?=(/&gt;)|(?:(&lt;/)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;)))</string>
+            <string>(?=[/]?&gt;)</string>
             <key>patterns</key>
             <array>
               <dict>
-                <key>begin</key>
-                <string>\G(?![/]?&gt;)</string>
-                <key>end</key>
-                <string>(?=[/]?&gt;)</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>include</key>
-                    <string>#comment</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#jsx-tag-attributes</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#jsx-tag-attributes-illegal</string>
-                  </dict>
-                </array>
+                <key>include</key>
+                <string>#comment</string>
               </dict>
               <dict>
-                <key>begin</key>
-                <string>(&gt;)</string>
-                <key>beginCaptures</key>
-                <dict>
-                  <key>1</key>
-                  <dict>
-                    <key>name</key>
-                    <string>punctuation.definition.tag.end.tsx</string>
-                  </dict>
-                </dict>
-                <key>end</key>
-                <string>(?=&lt;/)</string>
-                <key>contentName</key>
-                <string>meta.jsx.children.tsx</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>include</key>
-                    <string>#jsx-children</string>
-                  </dict>
-                </array>
+                <key>include</key>
+                <string>#jsx-tag-attributes</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#jsx-tag-attributes-illegal</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
+            <key>begin</key>
+            <string>(&gt;)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.tag.end.tsx</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?=&lt;/)</string>
+            <key>contentName</key>
+            <string>meta.jsx.children.tsx</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#jsx-children</string>
               </dict>
             </array>
           </dict>
@@ -5394,7 +5447,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#jsx-tag</string>
+            <string>#jsx-child-tag</string>
           </dict>
           <dict>
             <key>include</key>
@@ -5422,7 +5475,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#jsx-tag</string>
+            <string>#jsx-tag-in-expression</string>
           </dict>
           <dict>
             <key>include</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1577,7 +1577,7 @@
         <key>name</key>
         <string>meta.method.declaration.tsx</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1655,7 +1655,7 @@
         <key>name</key>
         <string>meta.method.overload.declaration.tsx</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -5465,8 +5465,6 @@
       </dict>
       <key>jsx</key>
       <dict>
-        <key>name</key>
-        <string>meta.jsx.tsx</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -5172,7 +5172,7 @@
       <key>jsx-evaluated-code</key>
       <dict>
         <key>name</key>
-        <string>meta.brace.curly.tsx</string>
+        <string>meta.embedded.expression.tsx</string>
         <key>begin</key>
         <string>{</string>
         <key>end</key>
@@ -5182,7 +5182,7 @@
           <key>0</key>
           <dict>
             <key>name</key>
-            <string>punctuation.definition.brace.curly.start.tsx</string>
+            <string>punctuation.section.embedded.begin.tsx</string>
           </dict>
         </dict>
         <key>endCaptures</key>
@@ -5190,7 +5190,7 @@
           <key>0</key>
           <dict>
             <key>name</key>
-            <string>punctuation.definition.brace.curly.end.tsx</string>
+            <string>punctuation.section.embedded.end.tsx</string>
           </dict>
         </dict>
         <key>patterns</key>

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -199,7 +199,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>invalid.illegal.attribute.tsx, meta.brace.curly.tsx</string>
+        <string>invalid.illegal.attribute.tsx, meta.embedded.expression.tsx</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>

--- a/tests/baselines/Issue280.baseline.txt
+++ b/tests/baselines/Issue280.baseline.txt
@@ -1,0 +1,354 @@
+original file
+-----------------------------------
+// @onlyOwnGrammar - As this has jsx
+class c {
+ private renderForecastsTable() {
+     let forecasts = this.props.forecasts.map(forecast => {
+     return forecast.dateFormatted +
+        forecast.temperatureC +
+        forecast.temperatureF +
+        forecast.summar;
+    });
+    return <table className="table">
+    <thread>
+    </thread>
+    <tbody>
+    {
+      this.props.forecasts.map(forecast => {
+     return forecast.dateFormatted +
+        forecast.temperatureC +
+        forecast.temperatureF +
+        forecast.summar;
+    }) 
+    }
+    </tbody>
+    </table>;
+ }
+
+}
+-----------------------------------
+
+Grammar: TypeScriptReact.tmLanguage
+-----------------------------------
+>// @onlyOwnGrammar - As this has jsx
+ ^^
+ source.tsx comment.line.double-slash.tsx punctuation.definition.comment.tsx
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   source.tsx comment.line.double-slash.tsx
+>class c {
+ ^^^^^
+ source.tsx meta.class.tsx storage.type.class.tsx
+      ^
+      source.tsx meta.class.tsx
+       ^
+       source.tsx meta.class.tsx entity.name.class.tsx
+        ^
+        source.tsx meta.class.tsx
+         ^
+         source.tsx meta.class.tsx punctuation.definition.block.tsx
+> private renderForecastsTable() {
+ ^
+ source.tsx meta.class.tsx
+  ^^^^^^^
+  source.tsx meta.class.tsx meta.method.declaration.tsx storage.modifier.tsx
+         ^
+         source.tsx meta.class.tsx meta.method.declaration.tsx
+          ^^^^^^^^^^^^^^^^^^^^
+          source.tsx meta.class.tsx meta.method.declaration.tsx entity.name.function.tsx
+                              ^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.parameters.tsx punctuation.definition.parameters.begin.tsx
+                               ^
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.parameters.tsx punctuation.definition.parameters.end.tsx
+                                ^
+                                source.tsx meta.class.tsx meta.method.declaration.tsx
+                                 ^
+                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.definition.block.tsx
+>     let forecasts = this.props.forecasts.map(forecast => {
+ ^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+      ^^^
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx storage.type.tsx
+         ^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx
+          ^^^^^^^^^
+          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx variable.other.readwrite.tsx
+                   ^
+                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                      ^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx variable.language.this.tsx
+                          ^
+                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx punctuation.accessor.tsx
+                           ^^^^^
+                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx variable.other.object.property.tsx
+                                ^
+                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx punctuation.accessor.tsx
+                                 ^^^^^^^^^
+                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx variable.other.object.property.tsx
+                                          ^
+                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx punctuation.accessor.tsx
+                                           ^^^
+                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx entity.name.function.tsx
+                                              ^
+                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+                                               ^^^^^^^^
+                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx variable.parameter.tsx
+                                                       ^
+                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx
+                                                        ^^
+                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx storage.type.function.arrow.tsx
+                                                          ^
+                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx
+                                                           ^
+                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
+>     return forecast.dateFormatted +
+ ^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+      ^^^^^^
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.control.flow.tsx
+            ^
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+             ^^^^^^^^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                      ^^^^^^^^^^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                                   ^
+                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+                                    ^
+                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+>        forecast.temperatureC +
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+         ^^^^^^^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                  ^^^^^^^^^^^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                              ^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+                               ^
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+>        forecast.temperatureF +
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+         ^^^^^^^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                  ^^^^^^^^^^^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                              ^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+                               ^
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+>        forecast.summar;
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+         ^^^^^^^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                  ^^^^^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                        ^
+                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.terminator.statement.tsx
+>    });
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+     ^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
+      ^
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+       ^
+       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.terminator.statement.tsx
+>    return <table className="table">
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+     ^^^^^^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx keyword.control.flow.tsx
+           ^
+           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+            ^
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+             ^^^^^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx entity.name.tag.tsx
+                  ^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                   ^^^^^^^^^
+                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                             ^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                              ^^^^^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx
+                                   ^
+                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                    ^
+                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+>    <thread>
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
+     ^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+      ^^^^^^
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+            ^
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+>    </thread>
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+     ^^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+       ^^^^^^
+       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+             ^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+>    <tbody>
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
+     ^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+      ^^^^^
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+           ^
+           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+>    {
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+     ^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+>      this.props.forecasts.map(forecast => {
+ ^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
+       ^^^^
+       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.language.this.tsx
+           ^
+           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
+            ^^^^^
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.object.property.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
+                  ^^^^^^^^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.object.property.tsx
+                           ^
+                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
+                            ^^^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx entity.name.function.tsx
+                               ^
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
+                                ^^^^^^^^
+                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx variable.parameter.tsx
+                                        ^
+                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx
+                                         ^^
+                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx storage.type.function.arrow.tsx
+                                           ^
+                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx
+                                            ^
+                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
+>     return forecast.dateFormatted +
+ ^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+      ^^^^^^
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx keyword.control.flow.tsx
+            ^
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+             ^^^^^^^^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                      ^^^^^^^^^^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                                   ^
+                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+                                    ^
+                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+>        forecast.temperatureC +
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+         ^^^^^^^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                  ^^^^^^^^^^^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                              ^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+                               ^
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+>        forecast.temperatureF +
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+         ^^^^^^^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                  ^^^^^^^^^^^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                              ^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+                               ^
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+>        forecast.summar;
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+         ^^^^^^^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                  ^^^^^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                        ^
+                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.terminator.statement.tsx
+>    }) 
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx
+     ^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
+      ^
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
+       ^^
+       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
+>    }
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
+     ^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+>    </tbody>
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+     ^^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+       ^^^^^
+       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+            ^
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+>    </table>;
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
+     ^^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+       ^^^^^
+       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx entity.name.tag.tsx
+            ^
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+             ^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.terminator.statement.tsx
+> }
+ ^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+  ^
+  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.definition.block.tsx
+>
+ ^
+ source.tsx meta.class.tsx
+>}
+ ^
+ source.tsx meta.class.tsx punctuation.definition.block.tsx

--- a/tests/baselines/Issue283.baseline.txt
+++ b/tests/baselines/Issue283.baseline.txt
@@ -1,0 +1,766 @@
+original file
+-----------------------------------
+// @onlyOwnGrammar - As this has jsx 
+import * as React from 'react';
+
+export default class Home extends React.Component<any, void> {
+    public render() {
+        return <div>
+            <h1>Hello, world!</h1>
+            <p>Welcome to your new single-page application, built with:</p>
+            <ul>
+                <li><a href='https://get.asp.net/'>ASP.NET Core</a> and <a href='https://msdn.microsoft.com/en-us/library/67ef8sbd.aspx'>C#</a> for cross-platform server-side code</li>
+                <li><a href='https://facebook.github.io/react/'>React</a>, <a href='http://redux.js.org'>Redux</a>, and <a href='http://www.typescriptlang.org/'>TypeScript</a> for client-side code</li>
+                <li><a href='https://webpack.github.io/'>Webpack</a> for building and bundling client-side resources</li>
+                <li><a href='http://getbootstrap.com/'>Bootstrap</a> for layout and styling</li>
+            </ul>
+            <p>To help you get started, we've also set up:</p>
+            <ul>
+                <li><strong>Client-side navigation</strong>. For example, click <em>Counter</em> then <em>Back</em> to return here.</li>
+                <li><strong>Webpack dev middleware</strong>. In development mode, there's no need to run the <code>webpack</code> build tool. Your client-side resources are dynamically built on demand. Updates are available as soon as you modify any file.</li>
+                <li><strong>Hot module replacement</strong>. In development mode, you don't even need to reload the page after making most changes. Within seconds of saving changes to files, rebuilt React components will be injected directly into your running application, preserving its live state.</li>
+                <li><strong>Efficient production builds</strong>. In production mode, development-time features are disabled, and the <code>webpack</code> build tool produces minified static CSS and JavaScript files.</li>
+                <li><strong>Server-side prerendering</strong>. To optimize startup time, your React application is first rendered on the server. The initial HTML and state is then transferred to the browser, where client-side code picks up where the server left off.</li>
+            </ul>
+        </div>;
+    }
+}
+-----------------------------------
+
+Grammar: TypeScriptReact.tmLanguage
+-----------------------------------
+>// @onlyOwnGrammar - As this has jsx 
+ ^^
+ source.tsx comment.line.double-slash.tsx punctuation.definition.comment.tsx
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   source.tsx comment.line.double-slash.tsx
+>import * as React from 'react';
+ ^^^^^^
+ source.tsx meta.import.tsx keyword.control.import.tsx
+       ^
+       source.tsx meta.import.tsx
+        ^
+        source.tsx meta.import.tsx constant.language.import-export-all.tsx
+         ^
+         source.tsx meta.import.tsx
+          ^^
+          source.tsx meta.import.tsx keyword.control.as.tsx
+            ^
+            source.tsx meta.import.tsx
+             ^^^^^
+             source.tsx meta.import.tsx variable.other.readwrite.alias.tsx
+                  ^
+                  source.tsx meta.import.tsx
+                   ^^^^
+                   source.tsx meta.import.tsx keyword.control.from.tsx
+                       ^
+                       source.tsx meta.import.tsx
+                        ^
+                        source.tsx meta.import.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                         ^^^^^
+                         source.tsx meta.import.tsx string.quoted.single.tsx
+                              ^
+                              source.tsx meta.import.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                               ^
+                               source.tsx punctuation.terminator.statement.tsx
+                                ^^
+                                source.tsx
+>
+ ^^
+ source.tsx
+>export default class Home extends React.Component<any, void> {
+ ^^^^^^
+ source.tsx meta.export.default.tsx keyword.control.export.tsx
+       ^
+       source.tsx meta.export.default.tsx
+        ^^^^^^^
+        source.tsx meta.export.default.tsx keyword.control.default.tsx
+               ^
+               source.tsx meta.export.default.tsx
+                ^^^^^
+                source.tsx meta.class.tsx storage.type.class.tsx
+                     ^
+                     source.tsx meta.class.tsx
+                      ^^^^
+                      source.tsx meta.class.tsx entity.name.class.tsx
+                          ^
+                          source.tsx meta.class.tsx
+                           ^^^^^^^
+                           source.tsx meta.class.tsx storage.modifier.tsx
+                                  ^
+                                  source.tsx meta.class.tsx
+                                   ^^^^^
+                                   source.tsx meta.class.tsx entity.name.type.module.tsx
+                                        ^
+                                        source.tsx meta.class.tsx punctuation.accessor.tsx
+                                         ^^^^^^^^^
+                                         source.tsx meta.class.tsx entity.other.inherited-class.tsx
+                                                  ^
+                                                  source.tsx meta.class.tsx meta.type.parameters.tsx punctuation.definition.typeparameters.begin.tsx
+                                                   ^^^
+                                                   source.tsx meta.class.tsx meta.type.parameters.tsx support.type.primitive.tsx
+                                                      ^
+                                                      source.tsx meta.class.tsx meta.type.parameters.tsx punctuation.separator.comma.tsx
+                                                       ^
+                                                       source.tsx meta.class.tsx meta.type.parameters.tsx
+                                                        ^^^^
+                                                        source.tsx meta.class.tsx meta.type.parameters.tsx support.type.primitive.tsx
+                                                            ^
+                                                            source.tsx meta.class.tsx meta.type.parameters.tsx punctuation.definition.typeparameters.end.tsx
+                                                             ^
+                                                             source.tsx meta.class.tsx
+                                                              ^
+                                                              source.tsx meta.class.tsx punctuation.definition.block.tsx
+                                                               ^^
+                                                               source.tsx meta.class.tsx
+>    public render() {
+ ^^^^
+ source.tsx meta.class.tsx
+     ^^^^^^
+     source.tsx meta.class.tsx meta.method.declaration.tsx storage.modifier.tsx
+           ^
+           source.tsx meta.class.tsx meta.method.declaration.tsx
+            ^^^^^^
+            source.tsx meta.class.tsx meta.method.declaration.tsx entity.name.function.tsx
+                  ^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.parameters.tsx punctuation.definition.parameters.begin.tsx
+                   ^
+                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.parameters.tsx punctuation.definition.parameters.end.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.definition.block.tsx
+                      ^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+>        return <div>
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+         ^^^^^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx keyword.control.flow.tsx
+               ^
+               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+                ^
+                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                 ^^^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>            <h1>Hello, world!</h1>
+ ^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+             ^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+              ^^
+              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                ^
+                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                 ^^^^^^^^^^^^^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                              ^^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                ^^
+                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                  ^
+                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                   ^^
+                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>            <p>Welcome to your new single-page application, built with:</p>
+ ^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+             ^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+              ^
+              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+               ^
+               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                        ^^
+                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                          ^
+                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                           ^
+                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                            ^^
+                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>            <ul>
+ ^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+             ^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+              ^^
+              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                ^
+                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                 ^^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><a href='https://get.asp.net/'>ASP.NET Core</a> and <a href='https://msdn.microsoft.com/en-us/library/67ef8sbd.aspx'>C#</a> for cross-platform server-side code</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                      ^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                       ^
+                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                        ^^^^
+                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                             ^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                              ^^^^^^^^^^^^^^^^^^^^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                                                  ^
+                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                                   ^
+                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                    ^^^^^^^^^^^^
+                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
+                                                                ^^
+                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                  ^
+                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                   ^
+                                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                    ^^^^^
+                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                         ^
+                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                          ^
+                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                           ^
+                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                                                                            ^^^^
+                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                                                                                ^
+                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                                                                                 ^
+                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                                                                                                                                        ^
+                                                                                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                                                                                                                         ^
+                                                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                          ^^
+                                                                                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
+                                                                                                                                            ^^
+                                                                                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                              ^
+                                                                                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                                                                                               ^
+                                                                                                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                                                                    ^^
+                                                                                                                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                                                      ^^
+                                                                                                                                                                                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                                                                        ^
+                                                                                                                                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                                         ^^
+                                                                                                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><a href='https://facebook.github.io/react/'>React</a>, <a href='http://redux.js.org'>Redux</a>, and <a href='http://www.typescriptlang.org/'>TypeScript</a> for client-side code</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                      ^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                       ^
+                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                        ^^^^
+                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                             ^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                                                               ^
+                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                                                ^
+                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                 ^^^^^
+                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
+                                                                      ^^
+                                                                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                        ^
+                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                         ^
+                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                          ^^
+                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                            ^
+                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                             ^
+                                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                              ^
+                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                                                                               ^^^^
+                                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                                                                                   ^
+                                                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                                                                                    ^
+                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                                                                                     ^^^^^^^^^^^^^^^^^^^
+                                                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                                                                                                        ^
+                                                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                                                                                         ^
+                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                                                          ^^^^^
+                                                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
+                                                                                                               ^^
+                                                                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                 ^
+                                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                                                                  ^
+                                                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                                                                   ^^^^^^
+                                                                                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                         ^
+                                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                          ^
+                                                                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                                                                           ^
+                                                                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                                                                                                                            ^^^^
+                                                                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                                                                                                                                ^
+                                                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                                                                                                                                 ^
+                                                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                                                                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                                                                                                                                                                ^
+                                                                                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                                                                                                                                                 ^
+                                                                                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                  ^^^^^^^^^^
+                                                                                                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
+                                                                                                                                                                            ^^
+                                                                                                                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                                              ^
+                                                                                                                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                                                                                                                               ^
+                                                                                                                                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                                ^^^^^^^^^^^^^^^^^^^^^
+                                                                                                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                                                                                     ^^
+                                                                                                                                                                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                                                                       ^^
+                                                                                                                                                                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                                                                                         ^
+                                                                                                                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                                                          ^^
+                                                                                                                                                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><a href='https://webpack.github.io/'>Webpack</a> for building and bundling client-side resources</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                      ^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                       ^
+                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                        ^^^^
+                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                             ^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                              ^^^^^^^^^^^^^^^^^^^^^^^^^^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                                                        ^
+                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                                         ^
+                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                          ^^^^^^^
+                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
+                                                                 ^^
+                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                   ^
+                                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                    ^
+                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                     ^^
+                                                                                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                       ^^
+                                                                                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                         ^
+                                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                          ^^
+                                                                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><a href='http://getbootstrap.com/'>Bootstrap</a> for layout and styling</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                      ^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                       ^
+                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                        ^^^^
+                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                             ^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                              ^^^^^^^^^^^^^^^^^^^^^^^^
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                                                      ^
+                                                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                                       ^
+                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                        ^^^^^^^^^
+                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
+                                                                 ^^
+                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                                                                   ^
+                                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+                                                                    ^
+                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                     ^^^^^^^^^^^^^^^^^^^^^^^
+                                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                            ^^
+                                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                              ^^
+                                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                ^
+                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                 ^^
+                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>            </ul>
+ ^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+             ^^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+               ^^
+               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>            <p>To help you get started, we've also set up:</p>
+ ^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+             ^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+              ^
+              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+               ^
+               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                           ^^
+                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                             ^
+                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                              ^
+                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                               ^^
+                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>            <ul>
+ ^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+             ^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+              ^^
+              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                ^
+                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                 ^^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><strong>Client-side navigation</strong>. For example, click <em>Counter</em> then <em>Back</em> to return here.</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                      ^^^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                             ^^^^^^^^^^^^^^^^^^^^^^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                   ^^
+                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                     ^^^^^^
+                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                           ^
+                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                            ^^^^^^^^^^^^^^^^^^^^^
+                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                 ^
+                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                  ^^
+                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                    ^
+                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                     ^^^^^^^
+                                                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                            ^^
+                                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                              ^^
+                                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                ^
+                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                 ^^^^^^
+                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                       ^
+                                                                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                        ^^
+                                                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                          ^
+                                                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                           ^^^^
+                                                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                               ^^
+                                                                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                 ^^
+                                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                   ^
+                                                                                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                    ^^^^^^^^^^^^^^^^
+                                                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                    ^^
+                                                                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                      ^^
+                                                                                                                                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                        ^
+                                                                                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                         ^^
+                                                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><strong>Webpack dev middleware</strong>. In development mode, there's no need to run the <code>webpack</code> build tool. Your client-side resources are dynamically built on demand. Updates are available as soon as you modify any file.</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                      ^^^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                             ^^^^^^^^^^^^^^^^^^^^^^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                   ^^
+                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                     ^^^^^^
+                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                           ^
+                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                              ^
+                                                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                               ^^^^
+                                                                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                   ^
+                                                                                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                    ^^^^^^^
+                                                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                           ^^
+                                                                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                             ^^^^
+                                                                                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                 ^
+                                                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                                                                                                                                                ^^
+                                                                                                                                                                                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                                                                                                                                  ^^
+                                                                                                                                                                                                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                                                                                                                                                    ^
+                                                                                                                                                                                                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                                                                                                                     ^^
+                                                                                                                                                                                                                                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><strong>Hot module replacement</strong>. In development mode, you don't even need to reload the page after making most changes. Within seconds of saving changes to files, rebuilt React components will be injected directly into your running application, preserving its live state.</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                      ^^^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                             ^^^^^^^^^^^^^^^^^^^^^^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                   ^^
+                                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                     ^^^^^^
+                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                           ^
+                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                                                                                                                                                                                            ^^
+                                                                                                                                                                                                                                                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                                                                                                                                                                              ^^
+                                                                                                                                                                                                                                                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                                                                                                                                                                                                ^
+                                                                                                                                                                                                                                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                                                                                                                                                                 ^^
+                                                                                                                                                                                                                                                                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><strong>Efficient production builds</strong>. In production mode, development-time features are disabled, and the <code>webpack</code> build tool produces minified static CSS and JavaScript files.</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                      ^^^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                        ^^
+                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                          ^^^^^^
+                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                ^
+                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                       ^
+                                                                                                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                        ^^^^
+                                                                                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                            ^
+                                                                                                                                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                             ^^^^^^^
+                                                                                                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                                    ^^
+                                                                                                                                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                      ^^^^
+                                                                                                                                                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                                          ^
+                                                                                                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                                                                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                                                                                                         ^^
+                                                                                                                                                                                                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                                                                                           ^^
+                                                                                                                                                                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                                                                                                             ^
+                                                                                                                                                                                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                                                                              ^^
+                                                                                                                                                                                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>                <li><strong>Server-side prerendering</strong>. To optimize startup time, your React application is first rendered on the server. The initial HTML and state is then transferred to the browser, where client-side code picks up where the server left off.</li>
+ ^^^^^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                    ^
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                     ^
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                      ^^^^^^
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                            ^
+                            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                             ^^^^^^^^^^^^^^^^^^^^^^^^
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                     ^^
+                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                       ^^^^^^
+                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                             ^
+                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+                                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                                                                                                                                                                                                                                           ^^
+                                                                                                                                                                                                                                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                                                                                                                                                                                                                             ^^
+                                                                                                                                                                                                                                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                                                                                                                                                                                                                               ^
+                                                                                                                                                                                                                                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                                                                                                                                                                                                                                ^^
+                                                                                                                                                                                                                                                                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>            </ul>
+ ^^^^^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+             ^^
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+               ^^
+               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                 ^
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                  ^^
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+>        </div>;
+ ^^^^^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+         ^^
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+           ^^^
+           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+              ^
+              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+               ^
+               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.terminator.statement.tsx
+                ^^
+                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+>    }
+ ^^^^
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx
+     ^
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.definition.block.tsx
+      ^^
+      source.tsx meta.class.tsx
+>}
+ ^
+ source.tsx meta.class.tsx punctuation.definition.block.tsx

--- a/tests/baselines/Issue285.baseline.txt
+++ b/tests/baselines/Issue285.baseline.txt
@@ -1,0 +1,80 @@
+original file
+-----------------------------------
+let model = {
+            links: {
+                new: "sample"
+            },
+        };
+
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>let model = {
+ ^^^
+ source.ts meta.var.expr.ts storage.type.ts
+    ^
+    source.ts meta.var.expr.ts
+     ^^^^^
+     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+          ^
+          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           ^
+           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            ^
+            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             ^
+             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+              ^^
+              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+>            links: {
+ ^^^^^^^^^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+             ^^^^^
+             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                  ^
+                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                   ^
+                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                    ^
+                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts punctuation.definition.block.ts
+                     ^^
+                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts
+>                new: "sample"
+ ^^^^^^^^^^^^^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts
+                 ^^^
+                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                    ^
+                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                     ^
+                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
+                      ^
+                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                       ^^^^^^
+                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts
+                             ^
+                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                              ^^
+                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
+>            },
+ ^^^^^^^^^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
+             ^
+             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts punctuation.definition.block.ts
+              ^
+              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+               ^^
+               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+>        };
+ ^^^^^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+         ^
+         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+          ^
+          source.ts punctuation.terminator.statement.ts
+           ^^
+           source.ts
+>
+ ^
+ source.ts

--- a/tests/baselines/TsxSamples.baseline.txt
+++ b/tests/baselines/TsxSamples.baseline.txt
@@ -127,34 +127,34 @@ Grammar: TypeScriptReact.tmLanguage
                             ^
                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx keyword.operator.assignment.tsx
                              ^
-                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                               ^^^^
-                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.brace.curly.tsx variable.language.this.tsx
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.embedded.expression.tsx variable.language.this.tsx
                                   ^
-                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                    ^^^^
-                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.brace.curly.tsx variable.other.property.tsx
+                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                        ^
-                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                         ^
                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >            This is a test: {this.state.count}
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
                              ^
-                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                               ^^^^
-                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.brace.curly.tsx variable.language.this.tsx
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.language.this.tsx
                                   ^
-                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                    ^^^^^
-                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.brace.curly.tsx variable.other.object.property.tsx
+                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.object.property.tsx
                                         ^
-                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                          ^^^^^
-                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.brace.curly.tsx variable.other.property.tsx
+                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                               ^
-                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
 >        </div>
  ^^^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
@@ -412,15 +412,15 @@ Grammar: TypeScriptReact.tmLanguage
  ^^^^^^^^
  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
           ^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx comment.block.tsx punctuation.definition.comment.tsx
+          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx comment.block.tsx
+            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx
                                           ^^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx comment.block.tsx punctuation.definition.comment.tsx
+                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
                                             ^
-                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
 >        <Person name={window.isLoggedIn ? window.name : ''}
  ^^^^^^^^
  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
@@ -435,37 +435,37 @@ Grammar: TypeScriptReact.tmLanguage
                      ^
                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
                       ^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                        ^^^^^^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx support.variable.dom.tsx
+                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                               ^^^^^^^^^^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx variable.other.property.tsx
+                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                         ^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx
+                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                          ^
-                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx keyword.operator.ternary.tsx
+                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.ternary.tsx
                                           ^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx
+                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                            ^^^^^^
-                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx support.variable.dom.tsx
+                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx
                                                  ^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                                   ^^^^
-                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx support.variable.property.dom.tsx
+                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.property.dom.tsx
                                                       ^
-                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx
+                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                                        ^
-                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx keyword.operator.ternary.tsx
+                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.ternary.tsx
                                                         ^
-                                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx
+                                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                                          ^
-                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                           ^
-                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                            ^
-                                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
 >        />
  ^^^^^^^^
  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
@@ -571,17 +571,17 @@ Grammar: TypeScriptReact.tmLanguage
                            ^
                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
                             ^
-                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                               ^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                 ^^^^^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx variable.other.property.tsx
+                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                      ^
-                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                       ^
                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
                                        ^^
@@ -644,17 +644,17 @@ Grammar: TypeScriptReact.tmLanguage
                             ^
                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                               ^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                 ^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                  ^^^^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx variable.other.property.tsx
+                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                       ^
-                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                        ^
                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx
                                         ^^^
@@ -662,15 +662,15 @@ Grammar: TypeScriptReact.tmLanguage
                                            ^
                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
                                             ^
-                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                                              ^
-                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                               ^^^^^^^^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx string.quoted.single.tsx
+                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                                                       ^
-                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                        ^
-                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                         ^
                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
                                                          ^^
@@ -708,19 +708,19 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                 ^^^^^^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx
+                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                       ^^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx constant.character.escape.tsx
+                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx constant.character.escape.tsx
                         ^^^^^^^^^^^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx
+                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                                    ^
-                                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                     ^
-                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                      ^^
                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                        ^^^
@@ -747,45 +747,45 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                 ^^^^^^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx
+                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                       ^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx
+                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                         ^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx keyword.operator.arithmetic.tsx
+                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx keyword.operator.arithmetic.tsx
                          ^
-                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx
+                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                           ^^^^^^
-                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx support.class.builtin.tsx
+                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.class.builtin.tsx
                                 ^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.accessor.tsx
+                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                  ^^^^^^^^^^^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx support.function.tsx
+                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.function.tsx
                                              ^
-                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.brace.round.tsx
+                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
                                               ^^^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx constant.numeric.decimal.tsx
+                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx constant.numeric.decimal.tsx
                                                  ^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.brace.round.tsx
+                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
                                                   ^
-                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx
+                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                                                    ^
-                                                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx keyword.operator.arithmetic.tsx
+                                                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx keyword.operator.arithmetic.tsx
                                                     ^
-                                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx
+                                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                                                      ^
-                                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                       ^^^^^^^
-                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx
+                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                                                              ^
-                                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                               ^
-                                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                                ^^
                                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                                  ^^^
@@ -812,51 +812,51 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.brace.square.tsx
+               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                 ^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                  ^^^^^^
-                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx string.quoted.single.tsx
+                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                         ^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
+                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
                          ^
-                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx
+                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx
                           ^
-                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                            ^^^^
-                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                                 ^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
+                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
                                  ^^^^^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx
+                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx
                                        ^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
+                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
                                         ^^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                           ^^^^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                               ^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                                                ^
-                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
+                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
                                                 ^
-                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx
+                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx
                                                  ^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                   ^^^^^^^
-                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx string.quoted.single.tsx
+                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx
                                                          ^
-                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                           ^
-                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.brace.square.tsx
+                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                                                            ^
-                                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                             ^^
                                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                               ^^^
@@ -887,25 +887,25 @@ Grammar: TypeScriptReact.tmLanguage
                                      ^
                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
                                       ^
-                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.start.tsx
+                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                                        ^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx punctuation.definition.block.tsx
                                         ^^^^^^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx
+                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx
                                               ^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx punctuation.separator.key-value.tsx
+                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx punctuation.separator.key-value.tsx
                                                ^
-                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx
+                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx
                                                 ^
-                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                  ^^^^^^^^^^^^^^^^^^^^^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx
+                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx
                                                                       ^
-                                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                                        ^
-                                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+                                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx punctuation.definition.block.tsx
                                                                         ^
-                                                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.definition.brace.curly.end.tsx
+                                                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                                          ^
                                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
                                                                           ^^

--- a/tests/baselines/TsxSamples.txt
+++ b/tests/baselines/TsxSamples.txt
@@ -69,7 +69,7 @@ Grammar: TypeScriptReact.tmLanguage
                      ^^^^^^^
                      [4, 21]: source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
                               ^^^^
-                              [4, 30]: source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.brace.curly.tsx variable.language.this.tsx 
+                              [4, 30]: source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.embedded.expression.tsx variable.language.this.tsx 
 >            This is a test: {this.state.count}
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  [5, 13]: source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx 
@@ -175,7 +175,7 @@ Grammar: TypeScriptReact.tmLanguage
                  ^^^^
                  [32, 17]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
                        ^^^^^^
-                       [32, 23]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.brace.curly.tsx support.variable.dom.tsx 
+                       [32, 23]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx 
 >        />
          ^^
          [33, 9]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
@@ -195,7 +195,7 @@ Grammar: TypeScriptReact.tmLanguage
                   ^^^^^^^^^
                   [42, 18]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx 
                              ^
-                             [42, 29]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx 
+                             [42, 29]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx 
                                        ^^
                                        [42, 39]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
 >
@@ -206,7 +206,7 @@ Grammar: TypeScriptReact.tmLanguage
                    ^^^^^^^^^
                    [45, 19]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx 
                               ^
-                              [45, 30]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx punctuation.accessor.tsx 
+                              [45, 30]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx 
                                                          ^^
                                                          [45, 57]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
 >
@@ -214,18 +214,18 @@ Grammar: TypeScriptReact.tmLanguage
 >// http://facebook.github.io/react/docs/jsx-gotchas.html
 >var a = <div>{'First \u00b7 Second'}</div>
                ^
-               [49, 15]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
+               [49, 15]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
 >var b = <div>{'First ' + String.fromCharCode(183) + ' Second'}</div>
                           ^^^^^^
-                          [50, 26]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx support.class.builtin.tsx 
+                          [50, 26]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.class.builtin.tsx 
 >var c = <div>{['First ', <span>&middot;</span>, ' Second']}</div>
                           ^
-                          [51, 26]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.brace.curly.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+                          [51, 26]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
 >var d = <div dangerouslySetInnerHTML={{__html: 'First &middot; Second'}} />
                                         ^^^^^^
-                                        [52, 40]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx 
+                                        [52, 40]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx 
                                                 ^
-                                                [52, 48]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.brace.curly.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
+                                                [52, 48]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
 >var e = <div data-custom-attribute="foo" />
                                      ^^^
                                      [53, 37]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx 

--- a/tests/cases/Issue280.tsx
+++ b/tests/cases/Issue280.tsx
@@ -1,0 +1,26 @@
+// @onlyOwnGrammar - As this has jsx
+class c {
+ private renderForecastsTable() {
+     let forecasts = this.props.forecasts.map(forecast => {
+     return forecast.dateFormatted +
+        forecast.temperatureC +
+        forecast.temperatureF +
+        forecast.summar;
+    });
+    return <table className="table">
+    <thread>
+    </thread>
+    <tbody>
+    {
+      this.props.forecasts.map(forecast => {
+     return forecast.dateFormatted +
+        forecast.temperatureC +
+        forecast.temperatureF +
+        forecast.summar;
+    }) 
+    }
+    </tbody>
+    </table>;
+ }
+
+}

--- a/tests/cases/Issue283.tsx
+++ b/tests/cases/Issue283.tsx
@@ -1,0 +1,25 @@
+// @onlyOwnGrammar - As this has jsx 
+import * as React from 'react';
+
+export default class Home extends React.Component<any, void> {
+    public render() {
+        return <div>
+            <h1>Hello, world!</h1>
+            <p>Welcome to your new single-page application, built with:</p>
+            <ul>
+                <li><a href='https://get.asp.net/'>ASP.NET Core</a> and <a href='https://msdn.microsoft.com/en-us/library/67ef8sbd.aspx'>C#</a> for cross-platform server-side code</li>
+                <li><a href='https://facebook.github.io/react/'>React</a>, <a href='http://redux.js.org'>Redux</a>, and <a href='http://www.typescriptlang.org/'>TypeScript</a> for client-side code</li>
+                <li><a href='https://webpack.github.io/'>Webpack</a> for building and bundling client-side resources</li>
+                <li><a href='http://getbootstrap.com/'>Bootstrap</a> for layout and styling</li>
+            </ul>
+            <p>To help you get started, we've also set up:</p>
+            <ul>
+                <li><strong>Client-side navigation</strong>. For example, click <em>Counter</em> then <em>Back</em> to return here.</li>
+                <li><strong>Webpack dev middleware</strong>. In development mode, there's no need to run the <code>webpack</code> build tool. Your client-side resources are dynamically built on demand. Updates are available as soon as you modify any file.</li>
+                <li><strong>Hot module replacement</strong>. In development mode, you don't even need to reload the page after making most changes. Within seconds of saving changes to files, rebuilt React components will be injected directly into your running application, preserving its live state.</li>
+                <li><strong>Efficient production builds</strong>. In production mode, development-time features are disabled, and the <code>webpack</code> build tool produces minified static CSS and JavaScript files.</li>
+                <li><strong>Server-side prerendering</strong>. To optimize startup time, your React application is first rendered on the server. The initial HTML and state is then transferred to the browser, where client-side code picks up where the server left off.</li>
+            </ul>
+        </div>;
+    }
+}

--- a/tests/cases/Issue285.ts
+++ b/tests/cases/Issue285.ts
@@ -1,0 +1,5 @@
+let model = {
+            links: {
+                new: "sample"
+            },
+        };


### PR DESCRIPTION
- Handles the ```new``` and ```constructor``` method starts by making sure they are not properties
- Renames the scope for jsx evaluated expression code to ```meta.embedded.expression```
- Handles the jsx tags from expression context and from jsx context separately since inspection of surrounding context is not needed when already in jsx context

Fixes #285, handles partially #280 so theme can make use of the updated scope name, Fixes #283 