### PR TITLE
Few bug fixes

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -1399,6 +1399,8 @@ repository:
       match: \*=|(?<!\()/=|%=|\+=|\-=
     - name: keyword.operator.assignment.compound.bitwise.ts
       match: \&=|\^=|<<=|>>=|>>>=|\|=
+    - name: keyword.operator.bitwise.shift.ts
+      match: <<|>>>|>>
     - name: keyword.operator.comparison.ts
       match: ===|!==|==|!=
     - name: keyword.operator.relational.ts
@@ -1746,27 +1748,25 @@ repository:
       match: (?<!\w)@(abstract|access|alias|arg|argument|async|attribute|augments|author|beta|borrows|bubbes|callback|chainable|class|classdesc|code|config|const|constant|constructor|constructs|copyright|default|defaultvalue|define|deprecated|desc|description|dict|emits|enum|event|example|exports?|extends|extension|extension_for|extensionfor|external|file|fileoverview|final|fires|for|function|global|host|ignore|implements|inherit[Dd]oc|inner|instance|interface|kind|lends|license|listens|main|member|memberof|method|mixex|mixins?|module|name|namespace|nocollapse|nosideeffects|override|overview|package|param|preserve|private|prop|property|protected|public|read[Oo]nly|record|require[ds]|returns?|see|since|static|struct|submodule|summary|template|this|throws|todo|tutorial|type|typedef|unrestricted|uses|var|variation|version|virtual|writeOnce)\b
     - match: |-
           (?x)
-          (?:(?<=@param)|(?<=@type))
+          (?:(?<=@param)|(?<=@arg)|(?<=@argument)|(?<=@type))
           \s+
           ({(?:
             \* |                                        # {*} any type
             \? |                                        # {?} unknown type
-
-            (?:                                          # Check for a prefix
+            (?:                                         # Check for a prefix
               \? |                                      # {?string} nullable type
-              !   |                                      # {!string} non-nullable type
+              !   |                                     # {!string} non-nullable type
               \.{3}                                     # {...string} variable number of parameters
             )?
-
             (?:
               \(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
                 [a-zA-Z_$]+
                 (?:
                   (?:
                     [\w$]*
-                    (?:\[\])?                          # {(string[]|number)} type application, an array of strings or a number
+                    (?:\[\])?                           # {(string[]|number)} type application, an array of strings or a number
                   ) |
-                  <[\w$]+(?:,\s+[\w$]+)*>             # {Array<string>} or {Object<string, number>} type application
+                  \.?<[\w$]+(?:,\s+[\w$]+)*>            # {Array<string>} or {Object<string, number>} type application (optional .)
                 )
                 (?:
                   [\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
@@ -1776,7 +1776,7 @@ repository:
                       [\w$]*
                       (?:\[\])?                        # {(string|number[])} type application, a string or an array of numbers
                     ) |
-                    <[\w$]+(?:,\s+[\w$]+)*>           # {Array<string>} or {Object<string, number>} type application
+                    \.?<[\w$]+(?:,\s+[\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)
                   )
                 )*
               \) |
@@ -1786,35 +1786,35 @@ repository:
                   [\w$]*
                   (?:\[\])?                            # {string[]|number} type application, an array of strings or a number
                 ) |
-                <[\w$]+(?:,\s+[\w$]+)*>               # {Array<string>} or {Object<string, number>} type application
+                \.?<[\w$]+(?:,\s+[\w$]+)*>             # {Array<string>} or {Object<string, number>} type application (optional .)
               )
               (?:
-                [\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                [\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                 [a-zA-Z_$]+
                 (?:
                   [\w$]* |
-                  <[\w$]+(?:,\s+[\w$]+)*>             # {Array<string>} or {Object<string, number>} type application
+                  \.?<[\w$]+(?:,\s+[\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)
                 )
               )*
             )
-                                                         # Check for suffix
+                                                       # Check for suffix
             (?:\[\])?                                  # {string[]} type application, an array of strings
-            =?                                           # {string=} optional parameter
+            =?                                         # {string=} optional parameter
           )})
           \s+
           (
-            \[                                          # [foo] optional parameter
+            \[                                         # [foo] optional parameter
               \s*
               (?:
                 [a-zA-Z_$][\w$]*
                 (?:
                   (?:\[\])?                            # Foo[].bar properties within an array
-                  \.                                    # Foo.Bar namespaced parameter
+                  \.                                   # Foo.Bar namespaced parameter
                   [a-zA-Z_$][\w$]*
                 )*
                 (?:
                   \s*
-                  =                                      # [foo=bar] Default parameter value
+                  =                                    # [foo=bar] Default parameter value
                   \s*
                   [\w$\s]*
                 )?
@@ -1825,12 +1825,13 @@ repository:
               [a-zA-Z_$][\w$]*
               (?:
                 (?:\[\])?                              # Foo[].bar properties within an array
-                \.                                      # Foo.Bar namespaced parameter
+                \.                                     # Foo.Bar namespaced parameter
                 [a-zA-Z_$][\w$]*
               )*
             )?
           )
           \s+
+          (?:-\s+)?                                    # optional hyphen before the description
           ((?:(?!\*\/).)*)                             # The type description
       captures:
         '0': { name: other.meta.jsdoc }
@@ -1840,50 +1841,51 @@ repository:
     - match: |-
           (?x)
           ({(?:
-            \* |                                        # {*} any type
-            \? |                                        # {?} unknown type
+            \* |                                       # {*} any type
+            \? |                                       # {?} unknown type
 
-            (?:                                          # Check for a prefix
-              \? |                                      # {?string} nullable type
-              !   |                                      # {!string} non-nullable type
-              \.{3}                                     # {...string} variable number of parameters
+            (?:                                        # Check for a prefix
+              \? |                                     # {?string} nullable type
+              !   |                                    # {!string} non-nullable type
+              \.{3}                                    # {...string} variable number of parameters
             )?
 
             (?:
-              \(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
+              \(                                       # Opening bracket of multiple types with parenthesis {(string|number)}
                 [a-zA-Z_$]+
                 (?:
                   [\w$]* |
-                  <[\w$]+(?:,\s+[\w$]+)*>             # {Array<string>} or {Object<string, number>} type application
+                  \.?<[\w$]+(?:,\s+[\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)
                 )
                 (?:
-                  [\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                  [\.|~]                               # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                   [a-zA-Z_$]+
                   (?:
                     [\w$]* |
-                    <[\w$]+(?:,\s+[\w$]+)*>           # {Array<string>} or {Object<string, number>} type application
+                    \.?<[\w$]+(?:,\s+[\w$]+)*>         # {Array<string>} or {Object<string, number>} type application (optional .)
                   )
                 )*
               \) |
               [a-zA-Z_$]+
               (?:
                 [\w$]* |
-                <[\w$]+(?:,\s+[\w$]+)*>               # {Array<string>} or {Object<string, number>} type application
+                \.?<[\w$]+(?:,\s+[\w$]+)*>             # {Array<string>} or {Object<string, number>} type application (optional .)
               )
               (?:
-                [\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+                [\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
                 [a-zA-Z_$]+
                 (?:
                   [\w$]* |
-                  <[\w$]+(?:,\s+[\w$]+)*>             # {Array<string>} or {Object<string, number>} type application
+                  \.?<[\w$]+(?:,\s+[\w$]+)*>           # {Array<string>} or {Object<string, number>} type application (optional .)
                 )
               )*
             )
-                                                         # Check for suffix
+                                                       # Check for suffix
             (?:\[\])?                                  # {string[]} type application, an array of strings
-            =?                                           # {string=} optional parameter
+            =?                                         # {string=} optional parameter
           )})
           \s+
+          (?:-\s+)?                                    # optional hyphen before the description
           ((?:(?!\*\/).)*)                             # The type description
       captures:
         '0': { name: other.meta.jsdoc }

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -1441,7 +1441,7 @@ repository:
         '1': { name: storage.modifier.async.ts }
         '2': { name: variable.parameter.ts }
     - name: meta.arrow.ts
-      begin: (?x)(?<=return|throw|yield|await|async|default|[=(\[,:>*])\s*(?=(<([^<>]|\<[^<>]+\>)+>\s*)?\(([^()]|\([^()]*\))*\)(\s*:\s*(.)*)?\s*=>)
+      begin: (?x)\s*(?=(<([^<>]|\<[^<>]+\>)+>\s*)?\(([^()]|\([^()]*\))*\)(\s*:\s*(.)*)?\s*=>)
       end: (?==>)
       patterns:
       - include: '#comment'

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -106,8 +106,10 @@ repository:
       - include: '#array-binding-pattern'
       - name: variable.other.readwrite.ts
         match: ([_$[:alpha:]][_$[:alnum:]]*)
+      - include: '#variable-initializer'
     - include: '#object-binding-pattern'
     - include: '#destructuring-variable-rest'
+    - include: '#variable-initializer'
     - include: '#punctuation-comma'
 
   array-binding-element:
@@ -116,6 +118,7 @@ repository:
     - include: '#object-binding-pattern'
     - include: '#array-binding-pattern'
     - include: '#destructuring-variable-rest'
+    - include: '#variable-initializer'
     - include: '#punctuation-comma'
 
   destructuring-variable-rest:
@@ -659,8 +662,10 @@ repository:
       - include: '#parameter-array-binding-pattern'
       - name: variable.parameter.ts
         match: ([_$[:alpha:]][_$[:alnum:]]*)
+      - include: '#variable-initializer'
     - include: '#parameter-object-binding-pattern'
     - include: '#destructuring-parameter-rest'
+    - include: '#variable-initializer'
     - include: '#punctuation-comma'
 
   parameter-array-binding-element:
@@ -669,6 +674,7 @@ repository:
     - include: '#parameter-object-binding-pattern'
     - include: '#parameter-array-binding-pattern'
     - include: '#destructuring-parameter-rest'
+    - include: '#variable-initializer'
     - include: '#punctuation-comma'
 
   destructuring-parameter-rest:
@@ -899,7 +905,7 @@ repository:
     begin: (?<!=|!)(=)(?!=)
     beginCaptures:
       '1': { name: keyword.operator.assignment.ts }
-    end: (?=$|[,);}])
+    end: (?=$|[,);}\]])
     patterns:
       - include: '#expression'
 

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -442,7 +442,6 @@ repository:
     - include: '#type-annotation'
     - include: '#variable-initializer'
     - include: '#access-modifier'
-    - include: '#static-modifier'
     - include: '#property-accessor'
     - include: '#expression'
     - include: '#punctuation-comma'
@@ -515,10 +514,10 @@ repository:
 
   method-overload-declaration:
     name: meta.method.overload.declaration.ts
-    begin: (?<!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
+    begin: (?<!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
     beginCaptures:
-      '1': { name: storage.modifier.ts } # captures keyword (abstract)
-      '2': { name: storage.modifier.ts } # captures keyword (public or private or protected)
+      '1': { name: storage.modifier.ts } # captures keyword (public or private or protected)
+      '2': { name: storage.modifier.ts } # captures keyword (abstract)
       '3': { name: storage.modifier.async.ts } # captures keyword (async)
       '4': { name: storage.type.property.ts } # captures keyword (get|set)
       '5': { name: keyword.operator.new.ts } # captures keyword (new)
@@ -621,12 +620,13 @@ repository:
     - include: '#object-member' 
 
   parameter-name:
-    match: '(?:\s*\b(public|private|protected)\b\s+)?(\.\.\.)?\s*(?<!=|:)([_$[:alpha:]][_$[:alnum:]]*)\s*(\??)'
+    match: '(?:\s*\b(readonly)\s+)?(?:\s*\b(public|private|protected)\s+)?(\.\.\.)?\s*(?<!=|:)([_$[:alpha:]][_$[:alnum:]]*)\s*(\??)'
     captures:
       '1': { name: storage.modifier.ts }
-      '2': { name: keyword.operator.rest.ts }
-      '3': { name: variable.parameter.ts }
-      '4': { name: keyword.operator.optional.ts }
+      '2': { name: storage.modifier.ts }
+      '3': { name: keyword.operator.rest.ts }
+      '4': { name: variable.parameter.ts }
+      '5': { name: keyword.operator.optional.ts }
 
   destructuring-parameter:
     patterns:
@@ -1713,11 +1713,7 @@ repository:
 
   access-modifier:
     name: storage.modifier.ts
-    match: (?<!\.|\$)\b(public|protected|private|readonly)\b(?!\$)
-
-  static-modifier:
-    name: storage.modifier.ts
-    match: (?<!\.|\$)\b(static)\b(?!\$)
+    match: (?<!\.|\$)\b(abstract|public|protected|private|readonly|static)\b(?!\$)
 
   property-accessor:
     name: storage.type.property.ts

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -411,9 +411,9 @@ repository:
     - include: "#string"
     - include: '#comment'
     - include: '#decorator'
-    - include: '#field-declaration'
     - include: '#method-declaration'
     - include: '#indexer-declaration'
+    - include: '#field-declaration'
     - include: '#type-annotation'
     - include: '#variable-initializer'
     - include: '#access-modifier'
@@ -436,9 +436,9 @@ repository:
   type-object-members:
     patterns:
     - include: '#comment'
-    - include: '#field-declaration'
     - include: '#method-declaration'
     - include: '#indexer-declaration'
+    - include: '#field-declaration'
     - include: '#type-annotation'
     - begin: \.\.\.
       beginCaptures:
@@ -451,27 +451,30 @@ repository:
 
   field-declaration:
     name: meta.field.declaration.ts
-    begin: (?<!\()(?:(?<!\.|\$)\b(readonly)\s+)?\s*((?:[_$[:alpha:]][_$[:alnum:]]*)|(?:\'[^']*\')|(?:\"[^"]*\"))\s*(\?\s*)?(?=(=|:))
+    begin: (?<!\()(?:(?<!\.|\$)\b(readonly)\s+)?(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\?\s*)?(=|:))
     beginCaptures:
       '1': { name: storage.modifier.ts }
-      '2': { name: variable.object.property.ts }
-      '3': { name: keyword.operator.optional.ts }
     end: '(?=\}|;|,|$)|(?<=\})'
     patterns:
     - include: '#variable-initializer'
-    - begin: \G
-      end: (?!\G)(?=[};,=]|$)|(?<=\})
+    - begin: (?=((?:[_$[:alpha:]][_$[:alnum:]]*)|(?:\'[^']*\')|(?:\"[^"]*\")|(\[[^\]]*\]))\s*(\?\s*)?(=|:))
+      end: (?=[};,=]|$)|(?<=\})
       patterns:
       - include: '#type-annotation'
       - include: '#string'
+      - include: '#array-literal'
       - include: '#comment'
+      - name: variable.object.property.ts
+        match: '[_$[:alpha:]][_$[:alnum:]]*'
+      - name: keyword.operator.optional.ts
+        match: \?
 
   method-declaration:
     name: meta.method.declaration.ts
-    begin: (?<!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
+    begin: (?<!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
     beginCaptures:
-      '1': { name: storage.modifier.ts } # captures keyword (abstract)
-      '2': { name: storage.modifier.ts } # captures keyword (public or private or protected)
+      '1': { name: storage.modifier.ts } # captures keyword (public or private or protected)
+      '2': { name: storage.modifier.ts } # captures keyword (abstract)
       '3': { name: storage.modifier.async.ts } # captures keyword (async)
       '4': { name: storage.type.property.ts } # captures keyword (get|set)
       '5': { name: keyword.operator.new.ts } # captures keyword (new)
@@ -488,7 +491,6 @@ repository:
     - include: '#decl-block'
 
   method-overload-declaration:
-    name: meta.method.overload.declaration.ts
     begin: (?<!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\<]))
     beginCaptures:
       '1': { name: storage.modifier.ts } # captures keyword (public or private or protected)
@@ -503,7 +505,7 @@ repository:
     - include: '#method-declaration-name'
 
   method-declaration-name:
-    begin: \G(?!\(|\<)
+    begin: (?=(([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??)\s*[\(\<])
     end: (?=\(|\<)
     patterns:
     - include: '#string'
@@ -515,23 +517,17 @@ repository:
     
   indexer-declaration:
     name: meta.indexer.declaration.ts
-    begin: (?:(?<!\.|\$)\b(readonly)\s*)?(\[)(?=\s*[_$[:alpha:]][_$[:alnum:]]*\s*[:\]])
+    begin: (?:(?<!\.|\$)\b(readonly)\s*)?(\[)\s*([_$[:alpha:]][_$[:alnum:]]*)\s*(?=:)
     beginCaptures:
       '1': { name: storage.modifier.ts }
       '2': { name: meta.brace.square.ts }
+      '3': { name: variable.parameter.ts}
     end: (\])\s*(\?\s*)?|$
     endCaptures:
       '1': { name: meta.brace.square.ts }
       '2': { name: keyword.operator.optional.ts }
     patterns:
     - include: '#type-annotation'
-    - include: '#indexer-parameter'
-
-  indexer-parameter:
-    name: meta.indexer.parameter.ts
-    match: ([_$[:alpha:]][_$[:alnum:]]*)
-    captures:
-      '1': { name: variable.parameter.ts}
 
   function-declaration:
     name: meta.function.ts

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -36,6 +36,7 @@ repository:
     patterns:
     - include: '#destructuring-variable'
     - include: '#var-single-variable'
+    - include: '#variable-initializer'
     - include: '#comment'
     - include: '#punctuation-comma'
 
@@ -44,54 +45,28 @@ repository:
     begin: ([_$[:alpha:]][_$[:alnum:]]*)
     beginCaptures:
       '1': { name: variable.other.readwrite.ts }
-    end: (?=$|[;,}]|(\s+(of|in)\s+))
+    end: (?=$|[;,=}]|(\s+(of|in)\s+))
     patterns:
-    - include: '#variable-initializer'
-    - begin: \G
-      end: (?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))
-      patterns:
-      - include: '#type-annotation'
-      - include: '#string'
-      - include: '#comment'
+    - include: '#type-annotation'
+    - include: '#string'
+    - include: '#comment'
 
   destructuring-variable:
     patterns:
     - name: meta.object-binding-pattern-variable.ts
-      begin: (?<!=|:|of|in)\s*(\{)
-      beginCaptures:
-        '1': { name: punctuation.definition.binding-pattern.object.ts }
-      end: (?=$|[;,}]|(\s+(of|in)\s+))
+      begin: (?<!=|:|of|in)\s*(?=\{)
+      end: (?=$|[;,=}]|(\s+(of|in)\s+))
       patterns:
-      - include: '#variable-initializer'
-      - begin: (?<=\{)
-        end: (?=$|[;,=}]|(\s+(of|in)\s+))
-        patterns:
-        - begin: (?<=\{)
-          end: \}
-          endCaptures:
-            '0': { name: punctuation.definition.binding-pattern.object.ts }
-          patterns:
-          - include: '#object-binding-element'
-        - include: '#type-annotation'
-        - include: '#comment'
+      - include: '#object-binding-pattern'
+      - include: '#type-annotation'
+      - include: '#comment'
     - name: meta.array-binding-pattern-variable.ts
-      begin: (?<!=|:|of|in)\s*(\[)
-      beginCaptures:
-        '1': { name: punctuation.definition.binding-pattern.array.ts }
-      end: (?=$|[;,}]|(\s+(of|in)\s+))
+      begin: (?<!=|:|of|in)\s*(?=\[)
+      end: (?=$|[;,=}]|(\s+(of|in)\s+))
       patterns:
-      - include: '#variable-initializer'
-      - begin: (?<=\[)
-        end: (?=$|[;,=}]|(\s+(of|in)\s+))
-        patterns:
-        - begin: (?<=\[)
-          end: \]
-          endCaptures:
-            '0': { name: punctuation.definition.binding-pattern.array.ts }
-          patterns:
-          - include: '#array-binding-element'
-        - include: '#type-annotation'
-        - include: '#comment'
+      - include: '#array-binding-pattern'
+      - include: '#type-annotation'
+      - include: '#comment'
 
   object-binding-element:
     patterns:

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1348,15 +1348,15 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#field-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#method-declaration</string>
           </dict>
           <dict>
             <key>include</key>
             <string>#indexer-declaration</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#field-declaration</string>
           </dict>
           <dict>
             <key>include</key>
@@ -1430,15 +1430,15 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#field-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#method-declaration</string>
           </dict>
           <dict>
             <key>include</key>
             <string>#indexer-declaration</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#field-declaration</string>
           </dict>
           <dict>
             <key>include</key>
@@ -1480,23 +1480,13 @@
         <key>name</key>
         <string>meta.field.declaration.ts</string>
         <key>begin</key>
-        <string>(?&lt;!\()(?:(?&lt;!\.|\$)\b(readonly)\s+)?\s*((?:[_$[:alpha:]][_$[:alnum:]]*)|(?:\'[^']*\')|(?:\"[^"]*\"))\s*(\?\s*)?(?=(=|:))</string>
+        <string>(?&lt;!\()(?:(?&lt;!\.|\$)\b(readonly)\s+)?(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\?\s*)?(=|:))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
             <string>storage.modifier.ts</string>
-          </dict>
-          <key>2</key>
-          <dict>
-            <key>name</key>
-            <string>variable.object.property.ts</string>
-          </dict>
-          <key>3</key>
-          <dict>
-            <key>name</key>
-            <string>keyword.operator.optional.ts</string>
           </dict>
         </dict>
         <key>end</key>
@@ -1509,9 +1499,9 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>\G</string>
+            <string>(?=((?:[_$[:alpha:]][_$[:alnum:]]*)|(?:\'[^']*\')|(?:\"[^"]*\")|(\[[^\]]*\]))\s*(\?\s*)?(=|:))</string>
             <key>end</key>
-            <string>(?!\G)(?=[};,=]|$)|(?&lt;=\})</string>
+            <string>(?=[};,=]|$)|(?&lt;=\})</string>
             <key>patterns</key>
             <array>
               <dict>
@@ -1524,7 +1514,23 @@
               </dict>
               <dict>
                 <key>include</key>
+                <string>#array-literal</string>
+              </dict>
+              <dict>
+                <key>include</key>
                 <string>#comment</string>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>variable.object.property.ts</string>
+                <key>match</key>
+                <string>[_$[:alpha:]][_$[:alnum:]]*</string>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>keyword.operator.optional.ts</string>
+                <key>match</key>
+                <string>\?</string>
               </dict>
             </array>
           </dict>
@@ -1535,7 +1541,7 @@
         <key>name</key>
         <string>meta.method.declaration.ts</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1610,8 +1616,6 @@
       </dict>
       <key>method-overload-declaration</key>
       <dict>
-        <key>name</key>
-        <string>meta.method.overload.declaration.ts</string>
         <key>begin</key>
         <string>(?&lt;!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
@@ -1665,7 +1669,7 @@
       <key>method-declaration-name</key>
       <dict>
         <key>begin</key>
-        <string>\G(?!\(|\&lt;)</string>
+        <string>(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??)\s*[\(\&lt;])</string>
         <key>end</key>
         <string>(?=\(|\&lt;)</string>
         <key>patterns</key>
@@ -1697,7 +1701,7 @@
         <key>name</key>
         <string>meta.indexer.declaration.ts</string>
         <key>begin</key>
-        <string>(?:(?&lt;!\.|\$)\b(readonly)\s*)?(\[)(?=\s*[_$[:alpha:]][_$[:alnum:]]*\s*[:\]])</string>
+        <string>(?:(?&lt;!\.|\$)\b(readonly)\s*)?(\[)\s*([_$[:alpha:]][_$[:alnum:]]*)\s*(?=:)</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1709,6 +1713,11 @@
           <dict>
             <key>name</key>
             <string>meta.brace.square.ts</string>
+          </dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>variable.parameter.ts</string>
           </dict>
         </dict>
         <key>end</key>
@@ -1732,26 +1741,7 @@
             <key>include</key>
             <string>#type-annotation</string>
           </dict>
-          <dict>
-            <key>include</key>
-            <string>#indexer-parameter</string>
-          </dict>
         </array>
-      </dict>
-      <key>indexer-parameter</key>
-      <dict>
-        <key>name</key>
-        <string>meta.indexer.parameter.ts</string>
-        <key>match</key>
-        <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
-        <key>captures</key>
-        <dict>
-          <key>1</key>
-          <dict>
-            <key>name</key>
-            <string>variable.parameter.ts</string>
-          </dict>
-        </dict>
       </dict>
       <key>function-declaration</key>
       <dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -3942,6 +3942,12 @@
           </dict>
           <dict>
             <key>name</key>
+            <string>keyword.operator.bitwise.shift.ts</string>
+            <key>match</key>
+            <string>&lt;&lt;|&gt;&gt;&gt;|&gt;&gt;</string>
+          </dict>
+          <dict>
+            <key>name</key>
             <string>keyword.operator.comparison.ts</string>
             <key>match</key>
             <string>===|!==|==|!=</string>
@@ -4929,27 +4935,25 @@
           <dict>
             <key>match</key>
             <string>(?x)
-(?:(?&lt;=@param)|(?&lt;=@type))
+(?:(?&lt;=@param)|(?&lt;=@arg)|(?&lt;=@argument)|(?&lt;=@type))
 \s+
 ({(?:
   \* |                                        # {*} any type
   \? |                                        # {?} unknown type
-
-  (?:                                          # Check for a prefix
+  (?:                                         # Check for a prefix
     \? |                                      # {?string} nullable type
-    !   |                                      # {!string} non-nullable type
+    !   |                                     # {!string} non-nullable type
     \.{3}                                     # {...string} variable number of parameters
   )?
-
   (?:
     \(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
       [a-zA-Z_$]+
       (?:
         (?:
           [\w$]*
-          (?:\[\])?                          # {(string[]|number)} type application, an array of strings or a number
+          (?:\[\])?                           # {(string[]|number)} type application, an array of strings or a number
         ) |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;            # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
       (?:
         [\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
@@ -4959,7 +4963,7 @@
             [\w$]*
             (?:\[\])?                        # {(string|number[])} type application, a string or an array of numbers
           ) |
-          &lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+          \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;         # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
         )
       )*
     \) |
@@ -4969,35 +4973,35 @@
         [\w$]*
         (?:\[\])?                            # {string[]|number} type application, an array of strings or a number
       ) |
-      &lt;[\w$]+(?:,\s+[\w$]+)*&gt;               # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+      \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
     )
     (?:
-      [\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+      [\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
       [a-zA-Z_$]+
       (?:
         [\w$]* |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
     )*
   )
-                                               # Check for suffix
+                                             # Check for suffix
   (?:\[\])?                                  # {string[]} type application, an array of strings
-  =?                                           # {string=} optional parameter
+  =?                                         # {string=} optional parameter
 )})
 \s+
 (
-  \[                                          # [foo] optional parameter
+  \[                                         # [foo] optional parameter
     \s*
     (?:
       [a-zA-Z_$][\w$]*
       (?:
         (?:\[\])?                            # Foo[].bar properties within an array
-        \.                                    # Foo.Bar namespaced parameter
+        \.                                   # Foo.Bar namespaced parameter
         [a-zA-Z_$][\w$]*
       )*
       (?:
         \s*
-        =                                      # [foo=bar] Default parameter value
+        =                                    # [foo=bar] Default parameter value
         \s*
         [\w$\s]*
       )?
@@ -5008,12 +5012,13 @@
     [a-zA-Z_$][\w$]*
     (?:
       (?:\[\])?                              # Foo[].bar properties within an array
-      \.                                      # Foo.Bar namespaced parameter
+      \.                                     # Foo.Bar namespaced parameter
       [a-zA-Z_$][\w$]*
     )*
   )?
 )
 \s+
+(?:-\s+)?                                    # optional hyphen before the description
 ((?:(?!\*\/).)*)                             # The type description</string>
             <key>captures</key>
             <dict>
@@ -5043,50 +5048,51 @@
             <key>match</key>
             <string>(?x)
 ({(?:
-  \* |                                        # {*} any type
-  \? |                                        # {?} unknown type
+  \* |                                       # {*} any type
+  \? |                                       # {?} unknown type
 
-  (?:                                          # Check for a prefix
-    \? |                                      # {?string} nullable type
-    !   |                                      # {!string} non-nullable type
-    \.{3}                                     # {...string} variable number of parameters
+  (?:                                        # Check for a prefix
+    \? |                                     # {?string} nullable type
+    !   |                                    # {!string} non-nullable type
+    \.{3}                                    # {...string} variable number of parameters
   )?
 
   (?:
-    \(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
+    \(                                       # Opening bracket of multiple types with parenthesis {(string|number)}
       [a-zA-Z_$]+
       (?:
         [\w$]* |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
       (?:
-        [\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+        [\.|~]                               # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
         [a-zA-Z_$]+
         (?:
           [\w$]* |
-          &lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+          \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;         # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
         )
       )*
     \) |
     [a-zA-Z_$]+
     (?:
       [\w$]* |
-      &lt;[\w$]+(?:,\s+[\w$]+)*&gt;               # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+      \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
     )
     (?:
-      [\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+      [\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
       [a-zA-Z_$]+
       (?:
         [\w$]* |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
     )*
   )
-                                               # Check for suffix
+                                             # Check for suffix
   (?:\[\])?                                  # {string[]} type application, an array of strings
-  =?                                           # {string=} optional parameter
+  =?                                         # {string=} optional parameter
 )})
 \s+
+(?:-\s+)?                                    # optional hyphen before the description
 ((?:(?!\*\/).)*)                             # The type description</string>
             <key>captures</key>
             <dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -4069,7 +4069,7 @@
             <key>name</key>
             <string>meta.arrow.ts</string>
             <key>begin</key>
-            <string>(?x)(?&lt;=return|throw|yield|await|async|default|[=(\[,:&gt;*])\s*(?=(&lt;([^&lt;&gt;]|\&lt;[^&lt;&gt;]+\&gt;)+&gt;\s*)?\(([^()]|\([^()]*\))*\)(\s*:\s*(.)*)?\s*=&gt;)</string>
+            <string>(?x)\s*(?=(&lt;([^&lt;&gt;]|\&lt;[^&lt;&gt;]+\&gt;)+&gt;\s*)?\(([^()]|\([^()]*\))*\)(\s*:\s*(.)*)?\s*=&gt;)</string>
             <key>end</key>
             <string>(?==&gt;)</string>
             <key>patterns</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -335,6 +335,10 @@
                 <key>match</key>
                 <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
               </dict>
+              <dict>
+                <key>include</key>
+                <string>#variable-initializer</string>
+              </dict>
             </array>
           </dict>
           <dict>
@@ -344,6 +348,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-variable-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -370,6 +378,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-variable-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2163,6 +2175,10 @@
                 <key>match</key>
                 <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
               </dict>
+              <dict>
+                <key>include</key>
+                <string>#variable-initializer</string>
+              </dict>
             </array>
           </dict>
           <dict>
@@ -2172,6 +2188,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-parameter-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2198,6 +2218,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-parameter-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2835,7 +2859,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=$|[,);}])</string>
+        <string>(?=$|[,);}\]])</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -112,6 +112,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#variable-initializer</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#comment</string>
           </dict>
           <dict>
@@ -135,33 +139,20 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=$|[;,}]|(\s+(of|in)\s+))</string>
+        <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
         <key>patterns</key>
         <array>
           <dict>
             <key>include</key>
-            <string>#variable-initializer</string>
+            <string>#type-annotation</string>
           </dict>
           <dict>
-            <key>begin</key>
-            <string>\G</string>
-            <key>end</key>
-            <string>(?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))</string>
-            <key>patterns</key>
-            <array>
-              <dict>
-                <key>include</key>
-                <string>#type-annotation</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>#string</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>#comment</string>
-              </dict>
-            </array>
+            <key>include</key>
+            <string>#string</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#comment</string>
           </dict>
         </array>
       </dict>
@@ -173,60 +164,22 @@
             <key>name</key>
             <string>meta.object-binding-pattern-variable.ts</string>
             <key>begin</key>
-            <string>(?&lt;!=|:|of|in)\s*(\{)</string>
-            <key>beginCaptures</key>
-            <dict>
-              <key>1</key>
-              <dict>
-                <key>name</key>
-                <string>punctuation.definition.binding-pattern.object.ts</string>
-              </dict>
-            </dict>
+            <string>(?&lt;!=|:|of|in)\s*(?=\{)</string>
             <key>end</key>
-            <string>(?=$|[;,}]|(\s+(of|in)\s+))</string>
+            <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
             <key>patterns</key>
             <array>
               <dict>
                 <key>include</key>
-                <string>#variable-initializer</string>
+                <string>#object-binding-pattern</string>
               </dict>
               <dict>
-                <key>begin</key>
-                <string>(?&lt;=\{)</string>
-                <key>end</key>
-                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>begin</key>
-                    <string>(?&lt;=\{)</string>
-                    <key>end</key>
-                    <string>\}</string>
-                    <key>endCaptures</key>
-                    <dict>
-                      <key>0</key>
-                      <dict>
-                        <key>name</key>
-                        <string>punctuation.definition.binding-pattern.object.ts</string>
-                      </dict>
-                    </dict>
-                    <key>patterns</key>
-                    <array>
-                      <dict>
-                        <key>include</key>
-                        <string>#object-binding-element</string>
-                      </dict>
-                    </array>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#type-annotation</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#comment</string>
-                  </dict>
-                </array>
+                <key>include</key>
+                <string>#type-annotation</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
               </dict>
             </array>
           </dict>
@@ -234,60 +187,22 @@
             <key>name</key>
             <string>meta.array-binding-pattern-variable.ts</string>
             <key>begin</key>
-            <string>(?&lt;!=|:|of|in)\s*(\[)</string>
-            <key>beginCaptures</key>
-            <dict>
-              <key>1</key>
-              <dict>
-                <key>name</key>
-                <string>punctuation.definition.binding-pattern.array.ts</string>
-              </dict>
-            </dict>
+            <string>(?&lt;!=|:|of|in)\s*(?=\[)</string>
             <key>end</key>
-            <string>(?=$|[;,}]|(\s+(of|in)\s+))</string>
+            <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
             <key>patterns</key>
             <array>
               <dict>
                 <key>include</key>
-                <string>#variable-initializer</string>
+                <string>#array-binding-pattern</string>
               </dict>
               <dict>
-                <key>begin</key>
-                <string>(?&lt;=\[)</string>
-                <key>end</key>
-                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>begin</key>
-                    <string>(?&lt;=\[)</string>
-                    <key>end</key>
-                    <string>\]</string>
-                    <key>endCaptures</key>
-                    <dict>
-                      <key>0</key>
-                      <dict>
-                        <key>name</key>
-                        <string>punctuation.definition.binding-pattern.array.ts</string>
-                      </dict>
-                    </dict>
-                    <key>patterns</key>
-                    <array>
-                      <dict>
-                        <key>include</key>
-                        <string>#array-binding-element</string>
-                      </dict>
-                    </array>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#type-annotation</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#comment</string>
-                  </dict>
-                </array>
+                <key>include</key>
+                <string>#type-annotation</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
               </dict>
             </array>
           </dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1457,10 +1457,6 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#static-modifier</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#property-accessor</string>
           </dict>
           <dict>
@@ -1702,7 +1698,7 @@
         <key>name</key>
         <string>meta.method.overload.declaration.ts</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -2040,7 +2036,7 @@
       <key>parameter-name</key>
       <dict>
         <key>match</key>
-        <string>(?:\s*\b(public|private|protected)\b\s+)?(\.\.\.)?\s*(?&lt;!=|:)([_$[:alpha:]][_$[:alnum:]]*)\s*(\??)</string>
+        <string>(?:\s*\b(readonly)\s+)?(?:\s*\b(public|private|protected)\s+)?(\.\.\.)?\s*(?&lt;!=|:)([_$[:alpha:]][_$[:alnum:]]*)\s*(\??)</string>
         <key>captures</key>
         <dict>
           <key>1</key>
@@ -2051,14 +2047,19 @@
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>keyword.operator.rest.ts</string>
+            <string>storage.modifier.ts</string>
           </dict>
           <key>3</key>
           <dict>
             <key>name</key>
-            <string>variable.parameter.ts</string>
+            <string>keyword.operator.rest.ts</string>
           </dict>
           <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>variable.parameter.ts</string>
+          </dict>
+          <key>5</key>
           <dict>
             <key>name</key>
             <string>keyword.operator.optional.ts</string>
@@ -4852,14 +4853,7 @@
         <key>name</key>
         <string>storage.modifier.ts</string>
         <key>match</key>
-        <string>(?&lt;!\.|\$)\b(public|protected|private|readonly)\b(?!\$)</string>
-      </dict>
-      <key>static-modifier</key>
-      <dict>
-        <key>name</key>
-        <string>storage.modifier.ts</string>
-        <key>match</key>
-        <string>(?&lt;!\.|\$)\b(static)\b(?!\$)</string>
+        <string>(?&lt;!\.|\$)\b(abstract|public|protected|private|readonly|static)\b(?!\$)</string>
       </dict>
       <key>property-accessor</key>
       <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -112,6 +112,10 @@
           </dict>
           <dict>
             <key>include</key>
+            <string>#variable-initializer</string>
+          </dict>
+          <dict>
+            <key>include</key>
             <string>#comment</string>
           </dict>
           <dict>
@@ -135,33 +139,20 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=$|[;,}]|(\s+(of|in)\s+))</string>
+        <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
         <key>patterns</key>
         <array>
           <dict>
             <key>include</key>
-            <string>#variable-initializer</string>
+            <string>#type-annotation</string>
           </dict>
           <dict>
-            <key>begin</key>
-            <string>\G</string>
-            <key>end</key>
-            <string>(?!\G)(?=$|[;,=}]|(\s+(of|in)\s+))</string>
-            <key>patterns</key>
-            <array>
-              <dict>
-                <key>include</key>
-                <string>#type-annotation</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>#string</string>
-              </dict>
-              <dict>
-                <key>include</key>
-                <string>#comment</string>
-              </dict>
-            </array>
+            <key>include</key>
+            <string>#string</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#comment</string>
           </dict>
         </array>
       </dict>
@@ -173,60 +164,22 @@
             <key>name</key>
             <string>meta.object-binding-pattern-variable.tsx</string>
             <key>begin</key>
-            <string>(?&lt;!=|:|of|in)\s*(\{)</string>
-            <key>beginCaptures</key>
-            <dict>
-              <key>1</key>
-              <dict>
-                <key>name</key>
-                <string>punctuation.definition.binding-pattern.object.tsx</string>
-              </dict>
-            </dict>
+            <string>(?&lt;!=|:|of|in)\s*(?=\{)</string>
             <key>end</key>
-            <string>(?=$|[;,}]|(\s+(of|in)\s+))</string>
+            <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
             <key>patterns</key>
             <array>
               <dict>
                 <key>include</key>
-                <string>#variable-initializer</string>
+                <string>#object-binding-pattern</string>
               </dict>
               <dict>
-                <key>begin</key>
-                <string>(?&lt;=\{)</string>
-                <key>end</key>
-                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>begin</key>
-                    <string>(?&lt;=\{)</string>
-                    <key>end</key>
-                    <string>\}</string>
-                    <key>endCaptures</key>
-                    <dict>
-                      <key>0</key>
-                      <dict>
-                        <key>name</key>
-                        <string>punctuation.definition.binding-pattern.object.tsx</string>
-                      </dict>
-                    </dict>
-                    <key>patterns</key>
-                    <array>
-                      <dict>
-                        <key>include</key>
-                        <string>#object-binding-element</string>
-                      </dict>
-                    </array>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#type-annotation</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#comment</string>
-                  </dict>
-                </array>
+                <key>include</key>
+                <string>#type-annotation</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
               </dict>
             </array>
           </dict>
@@ -234,60 +187,22 @@
             <key>name</key>
             <string>meta.array-binding-pattern-variable.tsx</string>
             <key>begin</key>
-            <string>(?&lt;!=|:|of|in)\s*(\[)</string>
-            <key>beginCaptures</key>
-            <dict>
-              <key>1</key>
-              <dict>
-                <key>name</key>
-                <string>punctuation.definition.binding-pattern.array.tsx</string>
-              </dict>
-            </dict>
+            <string>(?&lt;!=|:|of|in)\s*(?=\[)</string>
             <key>end</key>
-            <string>(?=$|[;,}]|(\s+(of|in)\s+))</string>
+            <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
             <key>patterns</key>
             <array>
               <dict>
                 <key>include</key>
-                <string>#variable-initializer</string>
+                <string>#array-binding-pattern</string>
               </dict>
               <dict>
-                <key>begin</key>
-                <string>(?&lt;=\[)</string>
-                <key>end</key>
-                <string>(?=$|[;,=}]|(\s+(of|in)\s+))</string>
-                <key>patterns</key>
-                <array>
-                  <dict>
-                    <key>begin</key>
-                    <string>(?&lt;=\[)</string>
-                    <key>end</key>
-                    <string>\]</string>
-                    <key>endCaptures</key>
-                    <dict>
-                      <key>0</key>
-                      <dict>
-                        <key>name</key>
-                        <string>punctuation.definition.binding-pattern.array.tsx</string>
-                      </dict>
-                    </dict>
-                    <key>patterns</key>
-                    <array>
-                      <dict>
-                        <key>include</key>
-                        <string>#array-binding-element</string>
-                      </dict>
-                    </array>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#type-annotation</string>
-                  </dict>
-                  <dict>
-                    <key>include</key>
-                    <string>#comment</string>
-                  </dict>
-                </array>
+                <key>include</key>
+                <string>#type-annotation</string>
+              </dict>
+              <dict>
+                <key>include</key>
+                <string>#comment</string>
               </dict>
             </array>
           </dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1352,15 +1352,15 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#field-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#method-declaration</string>
           </dict>
           <dict>
             <key>include</key>
             <string>#indexer-declaration</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#field-declaration</string>
           </dict>
           <dict>
             <key>include</key>
@@ -1434,15 +1434,15 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#field-declaration</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#method-declaration</string>
           </dict>
           <dict>
             <key>include</key>
             <string>#indexer-declaration</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#field-declaration</string>
           </dict>
           <dict>
             <key>include</key>
@@ -1484,23 +1484,13 @@
         <key>name</key>
         <string>meta.field.declaration.tsx</string>
         <key>begin</key>
-        <string>(?&lt;!\()(?:(?&lt;!\.|\$)\b(readonly)\s+)?\s*((?:[_$[:alpha:]][_$[:alnum:]]*)|(?:\'[^']*\')|(?:\"[^"]*\"))\s*(\?\s*)?(?=(=|:))</string>
+        <string>(?&lt;!\()(?:(?&lt;!\.|\$)\b(readonly)\s+)?(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\?\s*)?(=|:))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
           <dict>
             <key>name</key>
             <string>storage.modifier.tsx</string>
-          </dict>
-          <key>2</key>
-          <dict>
-            <key>name</key>
-            <string>variable.object.property.tsx</string>
-          </dict>
-          <key>3</key>
-          <dict>
-            <key>name</key>
-            <string>keyword.operator.optional.tsx</string>
           </dict>
         </dict>
         <key>end</key>
@@ -1513,9 +1503,9 @@
           </dict>
           <dict>
             <key>begin</key>
-            <string>\G</string>
+            <string>(?=((?:[_$[:alpha:]][_$[:alnum:]]*)|(?:\'[^']*\')|(?:\"[^"]*\")|(\[[^\]]*\]))\s*(\?\s*)?(=|:))</string>
             <key>end</key>
-            <string>(?!\G)(?=[};,=]|$)|(?&lt;=\})</string>
+            <string>(?=[};,=]|$)|(?&lt;=\})</string>
             <key>patterns</key>
             <array>
               <dict>
@@ -1528,7 +1518,23 @@
               </dict>
               <dict>
                 <key>include</key>
+                <string>#array-literal</string>
+              </dict>
+              <dict>
+                <key>include</key>
                 <string>#comment</string>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>variable.object.property.tsx</string>
+                <key>match</key>
+                <string>[_$[:alpha:]][_$[:alnum:]]*</string>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>keyword.operator.optional.tsx</string>
+                <key>match</key>
+                <string>\?</string>
               </dict>
             </array>
           </dict>
@@ -1539,7 +1545,7 @@
         <key>name</key>
         <string>meta.method.declaration.tsx</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1614,8 +1620,6 @@
       </dict>
       <key>method-overload-declaration</key>
       <dict>
-        <key>name</key>
-        <string>meta.method.overload.declaration.tsx</string>
         <key>begin</key>
         <string>(?&lt;!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
@@ -1669,7 +1673,7 @@
       <key>method-declaration-name</key>
       <dict>
         <key>begin</key>
-        <string>\G(?!\(|\&lt;)</string>
+        <string>(?=(([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??)\s*[\(\&lt;])</string>
         <key>end</key>
         <string>(?=\(|\&lt;)</string>
         <key>patterns</key>
@@ -1701,7 +1705,7 @@
         <key>name</key>
         <string>meta.indexer.declaration.tsx</string>
         <key>begin</key>
-        <string>(?:(?&lt;!\.|\$)\b(readonly)\s*)?(\[)(?=\s*[_$[:alpha:]][_$[:alnum:]]*\s*[:\]])</string>
+        <string>(?:(?&lt;!\.|\$)\b(readonly)\s*)?(\[)\s*([_$[:alpha:]][_$[:alnum:]]*)\s*(?=:)</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -1713,6 +1717,11 @@
           <dict>
             <key>name</key>
             <string>meta.brace.square.tsx</string>
+          </dict>
+          <key>3</key>
+          <dict>
+            <key>name</key>
+            <string>variable.parameter.tsx</string>
           </dict>
         </dict>
         <key>end</key>
@@ -1736,26 +1745,7 @@
             <key>include</key>
             <string>#type-annotation</string>
           </dict>
-          <dict>
-            <key>include</key>
-            <string>#indexer-parameter</string>
-          </dict>
         </array>
-      </dict>
-      <key>indexer-parameter</key>
-      <dict>
-        <key>name</key>
-        <string>meta.indexer.parameter.tsx</string>
-        <key>match</key>
-        <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
-        <key>captures</key>
-        <dict>
-          <key>1</key>
-          <dict>
-            <key>name</key>
-            <string>variable.parameter.tsx</string>
-          </dict>
-        </dict>
       </dict>
       <key>function-declaration</key>
       <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -335,6 +335,10 @@
                 <key>match</key>
                 <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
               </dict>
+              <dict>
+                <key>include</key>
+                <string>#variable-initializer</string>
+              </dict>
             </array>
           </dict>
           <dict>
@@ -344,6 +348,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-variable-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -370,6 +378,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-variable-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2167,6 +2179,10 @@
                 <key>match</key>
                 <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
               </dict>
+              <dict>
+                <key>include</key>
+                <string>#variable-initializer</string>
+              </dict>
             </array>
           </dict>
           <dict>
@@ -2176,6 +2192,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-parameter-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2202,6 +2222,10 @@
           <dict>
             <key>include</key>
             <string>#destructuring-parameter-rest</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#variable-initializer</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2839,7 +2863,7 @@
           </dict>
         </dict>
         <key>end</key>
-        <string>(?=$|[,);}])</string>
+        <string>(?=$|[,);}\]])</string>
         <key>patterns</key>
         <array>
           <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -3924,6 +3924,12 @@
           </dict>
           <dict>
             <key>name</key>
+            <string>keyword.operator.bitwise.shift.tsx</string>
+            <key>match</key>
+            <string>&lt;&lt;|&gt;&gt;&gt;|&gt;&gt;</string>
+          </dict>
+          <dict>
+            <key>name</key>
             <string>keyword.operator.comparison.tsx</string>
             <key>match</key>
             <string>===|!==|==|!=</string>
@@ -4911,27 +4917,25 @@
           <dict>
             <key>match</key>
             <string>(?x)
-(?:(?&lt;=@param)|(?&lt;=@type))
+(?:(?&lt;=@param)|(?&lt;=@arg)|(?&lt;=@argument)|(?&lt;=@type))
 \s+
 ({(?:
   \* |                                        # {*} any type
   \? |                                        # {?} unknown type
-
-  (?:                                          # Check for a prefix
+  (?:                                         # Check for a prefix
     \? |                                      # {?string} nullable type
-    !   |                                      # {!string} non-nullable type
+    !   |                                     # {!string} non-nullable type
     \.{3}                                     # {...string} variable number of parameters
   )?
-
   (?:
     \(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
       [a-zA-Z_$]+
       (?:
         (?:
           [\w$]*
-          (?:\[\])?                          # {(string[]|number)} type application, an array of strings or a number
+          (?:\[\])?                           # {(string[]|number)} type application, an array of strings or a number
         ) |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;            # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
       (?:
         [\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
@@ -4941,7 +4945,7 @@
             [\w$]*
             (?:\[\])?                        # {(string|number[])} type application, a string or an array of numbers
           ) |
-          &lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+          \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;         # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
         )
       )*
     \) |
@@ -4951,35 +4955,35 @@
         [\w$]*
         (?:\[\])?                            # {string[]|number} type application, an array of strings or a number
       ) |
-      &lt;[\w$]+(?:,\s+[\w$]+)*&gt;               # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+      \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
     )
     (?:
-      [\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+      [\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
       [a-zA-Z_$]+
       (?:
         [\w$]* |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
     )*
   )
-                                               # Check for suffix
+                                             # Check for suffix
   (?:\[\])?                                  # {string[]} type application, an array of strings
-  =?                                           # {string=} optional parameter
+  =?                                         # {string=} optional parameter
 )})
 \s+
 (
-  \[                                          # [foo] optional parameter
+  \[                                         # [foo] optional parameter
     \s*
     (?:
       [a-zA-Z_$][\w$]*
       (?:
         (?:\[\])?                            # Foo[].bar properties within an array
-        \.                                    # Foo.Bar namespaced parameter
+        \.                                   # Foo.Bar namespaced parameter
         [a-zA-Z_$][\w$]*
       )*
       (?:
         \s*
-        =                                      # [foo=bar] Default parameter value
+        =                                    # [foo=bar] Default parameter value
         \s*
         [\w$\s]*
       )?
@@ -4990,12 +4994,13 @@
     [a-zA-Z_$][\w$]*
     (?:
       (?:\[\])?                              # Foo[].bar properties within an array
-      \.                                      # Foo.Bar namespaced parameter
+      \.                                     # Foo.Bar namespaced parameter
       [a-zA-Z_$][\w$]*
     )*
   )?
 )
 \s+
+(?:-\s+)?                                    # optional hyphen before the description
 ((?:(?!\*\/).)*)                             # The type description</string>
             <key>captures</key>
             <dict>
@@ -5025,50 +5030,51 @@
             <key>match</key>
             <string>(?x)
 ({(?:
-  \* |                                        # {*} any type
-  \? |                                        # {?} unknown type
+  \* |                                       # {*} any type
+  \? |                                       # {?} unknown type
 
-  (?:                                          # Check for a prefix
-    \? |                                      # {?string} nullable type
-    !   |                                      # {!string} non-nullable type
-    \.{3}                                     # {...string} variable number of parameters
+  (?:                                        # Check for a prefix
+    \? |                                     # {?string} nullable type
+    !   |                                    # {!string} non-nullable type
+    \.{3}                                    # {...string} variable number of parameters
   )?
 
   (?:
-    \(                                        # Opening bracket of multiple types with parenthesis {(string|number)}
+    \(                                       # Opening bracket of multiple types with parenthesis {(string|number)}
       [a-zA-Z_$]+
       (?:
         [\w$]* |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
       (?:
-        [\.|~]                                # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+        [\.|~]                               # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
         [a-zA-Z_$]+
         (?:
           [\w$]* |
-          &lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+          \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;         # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
         )
       )*
     \) |
     [a-zA-Z_$]+
     (?:
       [\w$]* |
-      &lt;[\w$]+(?:,\s+[\w$]+)*&gt;               # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+      \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
     )
     (?:
-      [\.|~]                                  # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
+      [\.|~]                                 # {Foo.bar} namespaced, {string|number} multiple, {Foo~bar} class-specific callback
       [a-zA-Z_$]+
       (?:
         [\w$]* |
-        &lt;[\w$]+(?:,\s+[\w$]+)*&gt;             # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application
+        \.?&lt;[\w$]+(?:,\s+[\w$]+)*&gt;           # {Array&lt;string&gt;} or {Object&lt;string, number&gt;} type application (optional .)
       )
     )*
   )
-                                               # Check for suffix
+                                             # Check for suffix
   (?:\[\])?                                  # {string[]} type application, an array of strings
-  =?                                           # {string=} optional parameter
+  =?                                         # {string=} optional parameter
 )})
 \s+
+(?:-\s+)?                                    # optional hyphen before the description
 ((?:(?!\*\/).)*)                             # The type description</string>
             <key>captures</key>
             <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -4051,7 +4051,7 @@
             <key>name</key>
             <string>meta.arrow.tsx</string>
             <key>begin</key>
-            <string>(?x)(?&lt;=return|throw|yield|await|async|default|[=(\[,:&gt;*])\s*(?=(&lt;([^&lt;&gt;]|\&lt;[^&lt;&gt;]+\&gt;)+&gt;\s*)?\(([^()]|\([^()]*\))*\)(\s*:\s*(.)*)?\s*=&gt;)</string>
+            <string>(?x)\s*(?=(&lt;([^&lt;&gt;]|\&lt;[^&lt;&gt;]+\&gt;)+&gt;\s*)?\(([^()]|\([^()]*\))*\)(\s*:\s*(.)*)?\s*=&gt;)</string>
             <key>end</key>
             <string>(?==&gt;)</string>
             <key>patterns</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1461,10 +1461,6 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#static-modifier</string>
-          </dict>
-          <dict>
-            <key>include</key>
             <string>#property-accessor</string>
           </dict>
           <dict>
@@ -1706,7 +1702,7 @@
         <key>name</key>
         <string>meta.method.overload.declaration.tsx</string>
         <key>begin</key>
-        <string>(?&lt;!\.|\$)(?:\b(abstract)\s+)?(?:\b(public|private|protected)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
+        <string>(?&lt;!\.|\$)(?:\b(public|private|protected)\s+)?(?:\b(abstract)\s+)?(?:\b(async)\s+)?(?:\b(get|set)\s+)?(?:(?:\b(?:(new)|(constructor))\b(?!\$|:))|(?:(\*)\s*)?(?=((([_$[:alpha:]][_$[:alnum:]]*)|(\'[^']*\')|(\"[^"]*\")|(\[[^\]]*\]))\s*(\??))?\s*[\(\&lt;]))</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -2044,7 +2040,7 @@
       <key>parameter-name</key>
       <dict>
         <key>match</key>
-        <string>(?:\s*\b(public|private|protected)\b\s+)?(\.\.\.)?\s*(?&lt;!=|:)([_$[:alpha:]][_$[:alnum:]]*)\s*(\??)</string>
+        <string>(?:\s*\b(readonly)\s+)?(?:\s*\b(public|private|protected)\s+)?(\.\.\.)?\s*(?&lt;!=|:)([_$[:alpha:]][_$[:alnum:]]*)\s*(\??)</string>
         <key>captures</key>
         <dict>
           <key>1</key>
@@ -2055,14 +2051,19 @@
           <key>2</key>
           <dict>
             <key>name</key>
-            <string>keyword.operator.rest.tsx</string>
+            <string>storage.modifier.tsx</string>
           </dict>
           <key>3</key>
           <dict>
             <key>name</key>
-            <string>variable.parameter.tsx</string>
+            <string>keyword.operator.rest.tsx</string>
           </dict>
           <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>variable.parameter.tsx</string>
+          </dict>
+          <key>5</key>
           <dict>
             <key>name</key>
             <string>keyword.operator.optional.tsx</string>
@@ -4834,14 +4835,7 @@
         <key>name</key>
         <string>storage.modifier.tsx</string>
         <key>match</key>
-        <string>(?&lt;!\.|\$)\b(public|protected|private|readonly)\b(?!\$)</string>
-      </dict>
-      <key>static-modifier</key>
-      <dict>
-        <key>name</key>
-        <string>storage.modifier.tsx</string>
-        <key>match</key>
-        <string>(?&lt;!\.|\$)\b(static)\b(?!\$)</string>
+        <string>(?&lt;!\.|\$)\b(abstract|public|protected|private|readonly|static)\b(?!\$)</string>
       </dict>
       <key>property-accessor</key>
       <dict>

--- a/tests/baselines/Abstracts.baseline.txt
+++ b/tests/baselines/Abstracts.baseline.txt
@@ -41,7 +41,7 @@ Grammar: TypeScript.tmLanguage
     ^^^^^^
     source.ts meta.class.ts storage.modifier.ts
           ^
-          source.ts meta.class.ts meta.field.declaration.ts
+          source.ts meta.class.ts
            ^^^
            source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
               ^

--- a/tests/baselines/Abstracts.baseline.txt
+++ b/tests/baselines/Abstracts.baseline.txt
@@ -244,19 +244,19 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.var.expr.ts
            ^^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+           source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+              source.ts meta.var.expr.ts new.expr.ts
                ^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+               source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                  source.ts meta.var.expr.ts meta.brace.round.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                   source.ts meta.var.expr.ts meta.brace.round.ts
                     ^
                     source.ts punctuation.terminator.statement.ts
 >cow.makeSound();

--- a/tests/baselines/ArrowFunctionInsideTypeAssertion.baseline.txt
+++ b/tests/baselines/ArrowFunctionInsideTypeAssertion.baseline.txt
@@ -50,170 +50,170 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
 >    setTransform: <(domNode: HTMLElement, desiredValue: string) => void>null,
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^^^^^^^^^^^^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts
+                  source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.brace.angle.ts
+                   source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.brace.angle.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                      ^^^^^^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                            source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
+                             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
                               ^^^^^^^^^^^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                              source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.separator.parameter.ts
+                                         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.separator.parameter.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts
+                                          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts
                                            ^^^^^^^^^^^^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
+                                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
                                                        ^
-                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                                       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                                                         ^
-                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
+                                                        source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
                                                          ^^^^^^
-                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                                                         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                                                                ^
-                                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                                               source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                                                 ^
-                                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts
+                                                                source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts
                                                                  ^^
-                                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts
+                                                                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts
                                                                    ^
-                                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts
+                                                                   source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts
                                                                     ^^^^
-                                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts
+                                                                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts
                                                                         ^
-                                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.brace.angle.ts
+                                                                        source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.brace.angle.ts
                                                                          ^^^^
-                                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts constant.language.null.ts
+                                                                         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts constant.language.null.ts
                                                                              ^
-                                                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                                                             source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
 >    setDisplay: (domNode: HTMLElement, desiredValue: string) => {
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^^^^^^^^^^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts entity.name.function.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts entity.name.function.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+               source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts
+                source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                   ^^^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+                  source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+                          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
                            ^^^^^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts punctuation.separator.parameter.ts
+                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts punctuation.separator.parameter.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts
+                                       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts
                                         ^^^^^^^^^^^^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+                                        source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                                                     ^
-                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                                                      ^
-                                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+                                                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
                                                       ^^^^^^
-                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                                                             ^
-                                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                                            source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                                              ^
-                                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts
+                                                             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts
                                                               ^^
-                                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts storage.type.function.arrow.ts
+                                                              source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts storage.type.function.arrow.ts
                                                                 ^
-                                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts
+                                                                source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts
                                                                  ^
-                                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                                                                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
 >        if (domNode.style.display !== desiredValue) {
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
          ^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts keyword.control.conditional.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts keyword.control.conditional.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
+           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
              ^^^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts variable.other.object.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts variable.other.object.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
                      ^^^^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts support.variable.property.dom.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts support.variable.property.dom.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
+                          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
                            ^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts support.variable.property.dom.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts support.variable.property.dom.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
+                                  source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
                                    ^^^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts keyword.operator.comparison.ts
+                                   source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts keyword.operator.comparison.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
+                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
                                        ^^^^^^^^^^^^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts variable.other.readwrite.ts
+                                       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts variable.other.readwrite.ts
                                                    ^
-                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
+                                                   source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
                                                     ^
-                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
+                                                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
                                                      ^
-                                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.definition.block.ts
+                                                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.definition.block.ts
 >            domNode.style.display = desiredValue;
  ^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
              ^^^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts variable.other.object.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts variable.other.object.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.accessor.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.accessor.ts
                      ^^^^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts support.variable.property.dom.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts support.variable.property.dom.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.accessor.ts
+                          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.accessor.ts
                            ^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts support.variable.property.dom.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts support.variable.property.dom.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
+                                  source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts keyword.operator.assignment.ts
+                                   source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts keyword.operator.assignment.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
+                                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
                                      ^^^^^^^^^^^^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts variable.other.readwrite.ts
+                                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts variable.other.readwrite.ts
                                                  ^
-                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.terminator.statement.ts
+                                                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.terminator.statement.ts
 >        }
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.definition.block.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts meta.block.ts punctuation.definition.block.ts
 >    }
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
 >}
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
 >
  ^
  source.ts
@@ -340,37 +340,37 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts
+                source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts
                  ^
-                 source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.brace.angle.ts
+                 source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.brace.angle.ts
                   ^
-                  source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                  source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                    ^
-                   source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
+                   source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts
                     ^
-                    source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                    source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                      ^
-                     source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
+                     source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts
                       ^^^^^^
-                      source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                      source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                             ^
-                            source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                            source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                              ^
-                             source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts
+                             source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts
                               ^^
-                              source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts
+                              source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts
                                 ^
-                                source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts
+                                source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.return.ts
                                  ^^^^^^
-                                 source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts
+                                 source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts
                                        ^
-                                       source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.brace.angle.ts
+                                       source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.brace.angle.ts
                                         ^
-                                        source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                        source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts
                                          ^
-                                         source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                                         source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts
 >        return f("hello world")
  ^^^^^^^^
  source.ts meta.function.ts meta.block.ts meta.block.ts

--- a/tests/baselines/ArrowFunctionInsideTypeAssertion.txt
+++ b/tests/baselines/ArrowFunctionInsideTypeAssertion.txt
@@ -33,23 +33,23 @@ Grammar: TypeScript.tmLanguage
 >var object = {
 >    setTransform: <(domNode: HTMLElement, desiredValue: string) => void>null,
                    ^
-                   [5, 19]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.brace.angle.ts 
+                   [5, 19]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.brace.angle.ts 
                     ^
-                    [5, 20]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
+                    [5, 20]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
                      ^^^^^^^
-                     [5, 21]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts 
+                     [5, 21]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts 
                               ^^^^^^^^^^^
-                              [5, 30]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts 
+                              [5, 30]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts 
                                            ^^^^^^^^^^^^
-                                           [5, 43]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts 
+                                           [5, 43]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts 
                                                          ^^^^^^
-                                                         [5, 57]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts 
+                                                         [5, 57]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts 
                                                                  ^^
-                                                                 [5, 65]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts 
+                                                                 [5, 65]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts 
                                                                     ^^^^
-                                                                    [5, 68]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts 
+                                                                    [5, 68]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts 
                                                                          ^^^^
-                                                                         [5, 73]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts constant.language.null.ts 
+                                                                         [5, 73]: source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts constant.language.null.ts 
 >    setDisplay: (domNode: HTMLElement, desiredValue: string) => {
 >        if (domNode.style.display !== desiredValue) {
 >            domNode.style.display = desiredValue;
@@ -64,21 +64,21 @@ Grammar: TypeScript.tmLanguage
 >    else {
 >        let f = <(v: string) => number> x
                  ^
-                 [18, 17]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.brace.angle.ts 
+                 [18, 17]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.brace.angle.ts 
                   ^
-                  [18, 18]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
+                  [18, 18]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
                    ^
-                   [18, 19]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts 
+                   [18, 19]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts variable.parameter.ts 
                       ^^^^^^
-                      [18, 22]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts 
+                      [18, 22]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts 
                               ^^
-                              [18, 30]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts 
+                              [18, 30]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.return.ts storage.type.function.arrow.ts 
                                  ^^^^^^
-                                 [18, 33]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts 
+                                 [18, 33]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.type.function.return.ts support.type.primitive.ts 
                                        ^
-                                       [18, 39]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts cast.expr.ts meta.brace.angle.ts 
+                                       [18, 39]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts cast.expr.ts meta.brace.angle.ts 
                                          ^
-                                         [18, 41]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
+                                         [18, 41]: source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts 
 >        return f("hello world")
 >    }
 >}

--- a/tests/baselines/Comments.baseline.txt
+++ b/tests/baselines/Comments.baseline.txt
@@ -122,15 +122,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                       ^
                                       source.ts punctuation.terminator.statement.ts
 >var x /* comment */: string = "yahoo";
@@ -157,15 +157,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                       ^
                                       source.ts punctuation.terminator.statement.ts
 >var x: /* comment */ string = "yahoo";
@@ -192,15 +192,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                       ^
                                       source.ts punctuation.terminator.statement.ts
 >var x: string /* comment */ = "yahoo";
@@ -227,15 +227,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                       ^
                                       source.ts punctuation.terminator.statement.ts
 >var x: string = /* comment */ "yahoo";
@@ -254,23 +254,23 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                 source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                    ^^^^^^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts
+                   source.ts meta.var.expr.ts comment.block.ts
                             ^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                            source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                       ^
                                       source.ts punctuation.terminator.statement.ts
 >var x: string = "yahoo" /* comment */;
@@ -289,23 +289,23 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                 source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                   ^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                       source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                        source.ts meta.var.expr.ts
                          ^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                         source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                            ^^^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts
+                           source.ts meta.var.expr.ts comment.block.ts
                                     ^^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                                    source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                                       ^
                                       source.ts punctuation.terminator.statement.ts
 >var x: string = "yahoo"; /* comment */
@@ -324,15 +324,15 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                 source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                   ^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                       source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                         ^
                         source.ts punctuation.terminator.statement.ts
                          ^
@@ -370,15 +370,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >var x /* comment */: string = "yahoo"
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -403,15 +403,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >var x: /* comment */ string = "yahoo"
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -436,15 +436,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >var x: string /* comment */ = "yahoo"
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -469,15 +469,15 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >var x: string = /* comment */ "yahoo"
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -494,23 +494,23 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                 source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                    ^^^^^^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts
+                   source.ts meta.var.expr.ts comment.block.ts
                             ^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                            source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                 ^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                source.ts meta.var.expr.ts string.quoted.double.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >var x: string = "yahoo" /* comment */
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -527,23 +527,23 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                 source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                   ^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                       source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                        source.ts meta.var.expr.ts
                          ^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                         source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                            ^^^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts
+                           source.ts meta.var.expr.ts comment.block.ts
                                     ^^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                                    source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
 >
  ^
  source.ts
@@ -2027,17 +2027,17 @@ Grammar: TypeScript.tmLanguage
                 ^^
                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                  source.ts meta.var.expr.ts keyword.operator.assignment.ts
                    ^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+                   source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                      source.ts meta.var.expr.ts new.expr.ts
                        ^^^^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                       source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                             source.ts meta.var.expr.ts meta.brace.round.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                              source.ts meta.var.expr.ts meta.brace.round.ts
                                ^
                                source.ts punctuation.terminator.statement.ts
 >var x=/*comments*/new String();
@@ -2048,23 +2048,23 @@ Grammar: TypeScript.tmLanguage
      ^
      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
       ^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+      source.ts meta.var.expr.ts keyword.operator.assignment.ts
        ^^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+       source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
          ^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts
+         source.ts meta.var.expr.ts comment.block.ts
                  ^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                 source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                    ^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+                   source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                      source.ts meta.var.expr.ts new.expr.ts
                        ^^^^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                       source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                             source.ts meta.var.expr.ts meta.brace.round.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                              source.ts meta.var.expr.ts meta.brace.round.ts
                                ^
                                source.ts punctuation.terminator.statement.ts
 >var x= new/*comments*/String();
@@ -2075,23 +2075,23 @@ Grammar: TypeScript.tmLanguage
      ^
      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
       ^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+      source.ts meta.var.expr.ts keyword.operator.assignment.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+       source.ts meta.var.expr.ts
         ^^^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+        source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
            ^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
+           source.ts meta.var.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
              ^^^^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts
+             source.ts meta.var.expr.ts new.expr.ts comment.block.ts
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
+                     source.ts meta.var.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
                        ^^^^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                       source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                             source.ts meta.var.expr.ts meta.brace.round.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                              source.ts meta.var.expr.ts meta.brace.round.ts
                                ^
                                source.ts punctuation.terminator.statement.ts
 >
@@ -2115,19 +2115,19 @@ Grammar: TypeScript.tmLanguage
                      ^
                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                      source.ts meta.var.expr.ts keyword.operator.assignment.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.var.expr.ts
                         ^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+                        source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                           source.ts meta.var.expr.ts new.expr.ts
                             ^^^^^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                            source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                  source.ts meta.var.expr.ts meta.brace.round.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                   source.ts meta.var.expr.ts meta.brace.round.ts
                                     ^
                                     source.ts punctuation.terminator.statement.ts
 >var x = /* comments */ new String();
@@ -2140,27 +2140,27 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+         source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
            ^^^^^^^^^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts
+           source.ts meta.var.expr.ts comment.block.ts
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+                     source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.var.expr.ts
                         ^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+                        source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                           source.ts meta.var.expr.ts new.expr.ts
                             ^^^^^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                            source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                  source.ts meta.var.expr.ts meta.brace.round.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                   source.ts meta.var.expr.ts meta.brace.round.ts
                                     ^
                                     source.ts punctuation.terminator.statement.ts
 >var x = new /* comments */ String();
@@ -2173,26 +2173,26 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+         source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+            source.ts meta.var.expr.ts new.expr.ts
              ^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
+             source.ts meta.var.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
                ^^^^^^^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts
+               source.ts meta.var.expr.ts new.expr.ts comment.block.ts
                          ^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
+                         source.ts meta.var.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                           source.ts meta.var.expr.ts new.expr.ts
                             ^^^^^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                            source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                  source.ts meta.var.expr.ts meta.brace.round.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                   source.ts meta.var.expr.ts meta.brace.round.ts
                                     ^
                                     source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Comments.txt
+++ b/tests/baselines/Comments.txt
@@ -96,10 +96,10 @@ Grammar: TypeScript.tmLanguage
                [12, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts comment.block.ts punctuation.definition.comment.ts 
 >var x: string = /* comment */ "yahoo";
                  ^^
-                 [13, 17]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
+                 [13, 17]: source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >var x: string = "yahoo" /* comment */;
                          ^^
-                         [14, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
+                         [14, 25]: source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >var x: string = "yahoo"; /* comment */
                           ^^
                           [15, 26]: source.ts comment.block.ts punctuation.definition.comment.ts 
@@ -118,10 +118,10 @@ Grammar: TypeScript.tmLanguage
                [20, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts comment.block.ts punctuation.definition.comment.ts 
 >var x: string = /* comment */ "yahoo"
                  ^^
-                 [21, 17]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
+                 [21, 17]: source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >var x: string = "yahoo" /* comment */
                          ^^
-                         [22, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
+                         [22, 25]: source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >
 >/**/ interface i extends i1, i2, i3 {}
  ^^
@@ -284,17 +284,17 @@ Grammar: TypeScript.tmLanguage
       [64, 6]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >var x=/*comments*/new String();
        ^^
-       [65, 7]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
+       [65, 7]: source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >var x= new/*comments*/String();
            ^^
-           [66, 11]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts 
+           [66, 11]: source.ts meta.var.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >
 >var x /* comments */ = new String();
        ^^
        [68, 7]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >var x = /* comments */ new String();
          ^^
-         [69, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts 
+         [69, 9]: source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts 
 >var x = new /* comments */ String();
              ^^
-             [70, 13]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts 
+             [70, 13]: source.ts meta.var.expr.ts new.expr.ts comment.block.ts punctuation.definition.comment.ts 

--- a/tests/baselines/FunctionMethodOverloads.baseline.txt
+++ b/tests/baselines/FunctionMethodOverloads.baseline.txt
@@ -211,7 +211,7 @@ Grammar: TypeScript.tmLanguage
                                               ^
                                               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                                                ^
-                                               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                                               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                                                 ^
                                                 source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                                  ^
@@ -456,7 +456,7 @@ Grammar: TypeScript.tmLanguage
                                                       ^
                                                       source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.definition.block.ts
                                                        ^
-                                                       source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                                                       source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                                                         ^
                                                         source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                                          ^
@@ -468,7 +468,7 @@ Grammar: TypeScript.tmLanguage
                                                             ^
                                                             source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                                                              ^
-                                                             source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                                                             source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                                                               ^
                                                               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                                                ^
@@ -637,11 +637,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts
+     source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+           source.ts meta.class.ts meta.method.declaration.ts
             ^^^^^^^^^^^^^^^^^^
-            source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+            source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                               ^
                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                ^
@@ -658,11 +658,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts
+     source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+           source.ts meta.class.ts meta.method.declaration.ts
             ^^^^^^^^^^^^^^^^^^
-            source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+            source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                               ^
                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                ^
@@ -685,11 +685,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts
+     source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+           source.ts meta.class.ts meta.method.declaration.ts
             ^^^^^^^^^^^^^^^^^^
-            source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+            source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                               ^
                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                ^
@@ -708,11 +708,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts
+     source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+           source.ts meta.class.ts meta.method.declaration.ts
             ^^^^^^^^^^^^^^^^^^
-            source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+            source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                               ^
                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                ^
@@ -734,7 +734,7 @@ Grammar: TypeScript.tmLanguage
                                        ^
                                        source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                                         ^
-                                        source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                                        source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                                          ^
                                          source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                           ^
@@ -763,11 +763,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts
+     source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+           source.ts meta.class.ts meta.method.declaration.ts
             ^^^^^^^^^^^^^^^^^^
-            source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+            source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                               ^
                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                ^
@@ -969,7 +969,7 @@ Grammar: TypeScript.tmLanguage
                                                ^
                                                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.definition.block.ts
                                                 ^
-                                                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                                                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                                                  ^
                                                  source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                                   ^
@@ -981,7 +981,7 @@ Grammar: TypeScript.tmLanguage
                                                      ^
                                                      source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                                                       ^
-                                                      source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                                                      source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                                                        ^
                                                        source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                                         ^
@@ -1117,7 +1117,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+     source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
         ^
         source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
          ^
@@ -1168,11 +1168,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^^^^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts
+     source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts
              ^
-             source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+             source.ts meta.class.ts meta.method.declaration.ts
               ^^^
-              source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+              source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                  ^
                  source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                   ^

--- a/tests/baselines/FunctionMethodOverloads.txt
+++ b/tests/baselines/FunctionMethodOverloads.txt
@@ -135,29 +135,29 @@ Grammar: TypeScript.tmLanguage
             [23, 12]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >    public testMethodOverload(p: string)
      ^^^^^^
-     [24, 5]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts 
+     [24, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^
-            [24, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts 
+            [24, 12]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >    public testMethodOverload(p: string [])
      ^^^^^^
-     [25, 5]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts 
+     [25, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^
-            [25, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts 
+            [25, 12]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >    public testMethodOverload(p: {})
      ^^^^^^
-     [26, 5]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts 
+     [26, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^
-            [26, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts 
+            [26, 12]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >    public testMethodOverload(p: {a: A, b:B} | string [])
      ^^^^^^
-     [27, 5]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts 
+     [27, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^
-            [27, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts 
+            [27, 12]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >    public testMethodOverload(p: any): new() => any {
      ^^^^^^
-     [28, 5]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts 
+     [28, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^
-            [28, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts 
+            [28, 12]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >        throw new Error("")
          ^^^^^
          [29, 9]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts 
@@ -205,7 +205,7 @@ Grammar: TypeScript.tmLanguage
      [43, 5]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >    bar(): string;
      ^^^
-     [44, 5]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts 
+     [44, 5]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >}
 >
 >abstract class C {
@@ -216,7 +216,7 @@ Grammar: TypeScript.tmLanguage
               [48, 14]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >    abstract bar()
      ^^^^^^^^
-     [49, 5]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts storage.modifier.ts 
+     [49, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
               ^^^
-              [49, 14]: source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts 
+              [49, 14]: source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts 
 >}

--- a/tests/baselines/FunctionMethodParameters.baseline.txt
+++ b/tests/baselines/FunctionMethodParameters.baseline.txt
@@ -122,7 +122,7 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                ^
-               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                 ^
                 source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                  ^
@@ -275,7 +275,7 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                ^
-               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                 ^
                 source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                  ^
@@ -480,7 +480,7 @@ Grammar: TypeScript.tmLanguage
                   ^
                   source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                    ^
-                   source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                   source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                     ^
                     source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                      ^
@@ -633,7 +633,7 @@ Grammar: TypeScript.tmLanguage
                   ^
                   source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                    ^
-                   source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                   source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
                     ^
                     source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                      ^

--- a/tests/baselines/FunctionMethodReturnTypes.baseline.txt
+++ b/tests/baselines/FunctionMethodReturnTypes.baseline.txt
@@ -164,7 +164,7 @@ Grammar: TypeScript.tmLanguage
                                                  ^
                                                  source.ts meta.function.ts meta.return.type.ts meta.object.type.ts punctuation.separator.comma.ts
                                                   ^
-                                                  source.ts meta.function.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts
+                                                  source.ts meta.function.ts meta.return.type.ts meta.object.type.ts
                                                    ^
                                                    source.ts meta.function.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                                     ^
@@ -681,7 +681,7 @@ Grammar: TypeScript.tmLanguage
                                                   ^
                                                   source.ts meta.function.ts meta.return.type.ts meta.object.type.ts punctuation.separator.comma.ts
                                                    ^
-                                                   source.ts meta.function.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts
+                                                   source.ts meta.function.ts meta.return.type.ts meta.object.type.ts
                                                     ^
                                                     source.ts meta.function.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                                      ^
@@ -1066,7 +1066,7 @@ Grammar: TypeScript.tmLanguage
                                           ^
                                           source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts punctuation.separator.comma.ts
                                            ^
-                                           source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts
+                                           source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts
                                             ^
                                             source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                              ^
@@ -1569,7 +1569,7 @@ Grammar: TypeScript.tmLanguage
                                            ^
                                            source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts punctuation.separator.comma.ts
                                             ^
-                                            source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts
+                                            source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts
                                              ^
                                              source.ts meta.class.ts meta.method.declaration.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                               ^

--- a/tests/baselines/Issue10.baseline.txt
+++ b/tests/baselines/Issue10.baseline.txt
@@ -97,11 +97,11 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
                  ^
-                 source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                 source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                   ^
                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
                    ^^
@@ -174,11 +174,11 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
                  ^
-                 source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                 source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                   ^
                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
                    ^^

--- a/tests/baselines/Issue11.baseline.txt
+++ b/tests/baselines/Issue11.baseline.txt
@@ -22,9 +22,9 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+            source.ts meta.var.expr.ts constant.numeric.decimal.ts
              ^
              source.ts punctuation.terminator.statement.ts
               ^
@@ -63,11 +63,11 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.block.ts meta.var.expr.ts
              ^
-             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+             source.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
               ^
               source.ts meta.block.ts punctuation.terminator.statement.ts
                ^^
@@ -84,13 +84,13 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.block.ts meta.var.expr.ts
              ^
-             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+             source.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
               ^
-              source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+              source.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                ^
                source.ts meta.block.ts punctuation.terminator.statement.ts
                 ^^

--- a/tests/baselines/Issue110.baseline.txt
+++ b/tests/baselines/Issue110.baseline.txt
@@ -35,13 +35,13 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.hex.ts
+               source.ts meta.var.expr.ts constant.numeric.hex.ts
                     ^^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                    source.ts meta.var.expr.ts
 >let number2 = 14e15
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -52,11 +52,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number3 = 10.42e41.5 
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -67,21 +67,21 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                 source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                   ^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                       source.ts meta.var.expr.ts punctuation.accessor.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                        source.ts meta.var.expr.ts constant.numeric.decimal.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
 >let number4 = 4
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -92,11 +92,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number5 = 51.4
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -107,15 +107,15 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                 source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number6 = 12.4E10.2
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -126,19 +126,19 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                 source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                   ^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                      source.ts meta.var.expr.ts punctuation.accessor.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                       source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number7 = 14.6e+10
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -149,15 +149,15 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                 source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                   ^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number8 = 12E4
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -168,11 +168,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number9 = 10e10
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -183,11 +183,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number10 = 14e14.5
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -198,15 +198,15 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                     source.ts meta.var.expr.ts punctuation.accessor.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                      source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number11 = 12E-10
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -217,11 +217,11 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number12 = 13.4e-14.2
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -232,19 +232,19 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                    ^^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                   source.ts meta.var.expr.ts constant.numeric.decimal.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                        source.ts meta.var.expr.ts punctuation.accessor.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                         source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number13 = 14.12
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -255,15 +255,15 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                    ^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                   source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number14 = 10.2E+4
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -274,15 +274,15 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                    ^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                   source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let number6 = 5.00567789e+2
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -293,15 +293,15 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.var.expr.ts constant.numeric.decimal.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
                  ^^^^^^^^^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                 source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >let i = 1, j = 1e3
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -312,11 +312,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
           ^
           source.ts meta.var.expr.ts punctuation.separator.comma.ts
            ^
@@ -326,11 +326,11 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
 >
  ^
  source.ts

--- a/tests/baselines/Issue110.txt
+++ b/tests/baselines/Issue110.txt
@@ -27,54 +27,54 @@ Grammar: TypeScript.tmLanguage
 -----------------------------------
 >let number1 = 0x100   
                ^^^^^
-               [1, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.hex.ts 
+               [1, 15]: source.ts meta.var.expr.ts constant.numeric.hex.ts 
 >let number2 = 14e15
                ^^^^^
-               [2, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [2, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number3 = 10.42e41.5 
                ^^
-               [3, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [3, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number4 = 4
                ^
-               [4, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [4, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number5 = 51.4
                ^^
-               [5, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [5, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number6 = 12.4E10.2
                ^^
-               [6, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [6, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number7 = 14.6e+10
                ^^
-               [7, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [7, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number8 = 12E4
                ^^^^
-               [8, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [8, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number9 = 10e10
                ^^^^^
-               [9, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [9, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number10 = 14e14.5
                 ^^^^^
-                [10, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+                [10, 16]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number11 = 12E-10
                 ^^^^^^
-                [11, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+                [11, 16]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number12 = 13.4e-14.2
                 ^^
-                [12, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+                [12, 16]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number13 = 14.12
                 ^^
-                [13, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+                [13, 16]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number14 = 10.2E+4
                 ^^
-                [14, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+                [14, 16]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let number6 = 5.00567789e+2
                ^
-               [15, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+               [15, 15]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >let i = 1, j = 1e3
          ^
-         [16, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+         [16, 9]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
                 ^^^
-                [16, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+                [16, 16]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >
 >/*
 >

--- a/tests/baselines/Issue114.baseline.txt
+++ b/tests/baselines/Issue114.baseline.txt
@@ -108,7 +108,7 @@ Grammar: TypeScript.tmLanguage
                  source.ts meta.class.ts
 >  type: 'line' | 'call' | 'return';
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
        ^

--- a/tests/baselines/Issue115.baseline.txt
+++ b/tests/baselines/Issue115.baseline.txt
@@ -132,47 +132,47 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^^^^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts storage.type.function.ts
+             source.ts meta.var.expr.ts meta.function.ts storage.type.function.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts
+                     source.ts meta.var.expr.ts meta.function.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                      source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
+                       source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                        source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts
+                         source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts
                           ^^^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                          source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.separator.parameter.ts
+                             source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.separator.parameter.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts
+                              source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
+                               source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts
+                                 source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts
                                   ^^^^^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                                  source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                        source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts
+                                         source.ts meta.var.expr.ts meta.function.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                                          source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+                                           source.ts meta.var.expr.ts meta.function.ts meta.block.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                                            source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                             source.ts meta.var.expr.ts
 >
  ^^
  source.ts
@@ -186,45 +186,45 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+            source.ts meta.var.expr.ts meta.arrow.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+             source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+              source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+               source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+                source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
                  ^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                 source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.separator.parameter.ts
+                    source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.separator.parameter.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts
+                     source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+                      source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                       source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+                        source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
                          ^^^^^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                         source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                               source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                source.ts meta.var.expr.ts meta.arrow.ts
                                  ^^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                 source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                   source.ts meta.var.expr.ts meta.arrow.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                                    source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+                                     source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                                      source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                                        ^
                                        source.ts punctuation.terminator.statement.ts
                                         ^^
@@ -242,85 +242,85 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
               ^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts
 >    bar(a: Foo, b: string) { },
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^^^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+        source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+          source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+           source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
             ^^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.separator.parameter.ts
+               source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.separator.parameter.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts
+                source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                  source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                   source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
                     ^^^^^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                          source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                            source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                             source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                              source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                               source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                                 ^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                source.ts meta.var.expr.ts meta.object-literal.ts
 >    set bar2(x: string) { }
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^^^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts storage.type.property.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts storage.type.property.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts
+        source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts
          ^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+               source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
                  ^^^^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                       source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts
+                        source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                         source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                          source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
                             ^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                            source.ts meta.var.expr.ts meta.object-literal.ts
 >}
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts

--- a/tests/baselines/Issue119.baseline.txt
+++ b/tests/baselines/Issue119.baseline.txt
@@ -82,7 +82,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^^^^^^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                       ^

--- a/tests/baselines/Issue124.baseline.txt
+++ b/tests/baselines/Issue124.baseline.txt
@@ -45,27 +45,27 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+         source.ts meta.var.expr.ts constant.language.boolean.true.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+              source.ts meta.var.expr.ts keyword.operator.ternary.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+                source.ts meta.var.expr.ts constant.language.boolean.true.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                    source.ts meta.var.expr.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                     source.ts meta.var.expr.ts keyword.operator.ternary.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                      source.ts meta.var.expr.ts
                        ^^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+                       source.ts meta.var.expr.ts constant.language.boolean.true.ts
                            ^
                            source.ts punctuation.terminator.statement.ts
                             ^^^
@@ -80,37 +80,37 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+         source.ts meta.var.expr.ts constant.language.boolean.true.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+              source.ts meta.var.expr.ts keyword.operator.ternary.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+                source.ts meta.var.expr.ts constant.language.boolean.true.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                    source.ts meta.var.expr.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                     source.ts meta.var.expr.ts keyword.operator.ternary.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                      source.ts meta.var.expr.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
+                       source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
                         ^^^^^^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts
+                        source.ts meta.var.expr.ts string.template.ts
                                 ^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
+                                source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
+                                  source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
                                    ^^^^^^^^^^^^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts
+                                   source.ts meta.var.expr.ts string.template.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.end.ts
+                                               source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.end.ts
 >let c = true ? `hello` : `this ${DEPENDENCY_SEPARATOR}${moduleName} is highlighted`;
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -121,49 +121,49 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+         source.ts meta.var.expr.ts constant.language.boolean.true.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+              source.ts meta.var.expr.ts keyword.operator.ternary.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
+                source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
                  ^^^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts
+                 source.ts meta.var.expr.ts string.template.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.end.ts
+                      source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.end.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.var.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                        source.ts meta.var.expr.ts keyword.operator.ternary.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
+                          source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
                            ^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts
+                           source.ts meta.var.expr.ts string.template.ts
                                 ^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
+                                source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
                                   ^^^^^^^^^^^^^^^^^^^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts constant.other.ts
+                                  source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts constant.other.ts
                                                       ^
-                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
+                                                      source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
                                                        ^^
-                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
+                                                       source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
                                                          ^^^^^^^^^^
-                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts variable.other.readwrite.ts
+                                                         source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts variable.other.readwrite.ts
                                                                    ^
-                                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
+                                                                   source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
                                                                     ^^^^^^^^^^^^^^^
-                                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts
+                                                                    source.ts meta.var.expr.ts string.template.ts
                                                                                    ^
-                                                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.end.ts
+                                                                                   source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.end.ts
                                                                                     ^
                                                                                     source.ts punctuation.terminator.statement.ts
 >
@@ -179,43 +179,43 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+              source.ts meta.var.expr.ts variable.other.readwrite.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                source.ts meta.var.expr.ts keyword.operator.ternary.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.var.expr.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                  source.ts meta.var.expr.ts meta.brace.round.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                   source.ts meta.var.expr.ts variable.other.readwrite.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                    source.ts meta.var.expr.ts
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.comparison.ts
+                     source.ts meta.var.expr.ts keyword.operator.comparison.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.var.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
+                        source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
                          ^^^^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts
+                         source.ts meta.var.expr.ts string.template.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.end.ts
+                              source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.end.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                               source.ts meta.var.expr.ts meta.brace.round.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                source.ts meta.var.expr.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                                 source.ts meta.var.expr.ts keyword.operator.ternary.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                  source.ts meta.var.expr.ts
                                    ^^^^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+                                   source.ts meta.var.expr.ts constant.language.boolean.true.ts
                                        ^
                                        source.ts punctuation.terminator.statement.ts
 >
@@ -231,47 +231,47 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+               source.ts meta.var.expr.ts variable.other.readwrite.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                   source.ts meta.var.expr.ts
                     ^^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.comparison.ts
+                    source.ts meta.var.expr.ts keyword.operator.comparison.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.var.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                        source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                          ^^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                         source.ts meta.var.expr.ts string.quoted.single.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                            source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                             source.ts meta.var.expr.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                              source.ts meta.var.expr.ts keyword.operator.ternary.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                               source.ts meta.var.expr.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                  ^^^^^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                                 source.ts meta.var.expr.ts string.quoted.single.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                      source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                       source.ts meta.var.expr.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                                        source.ts meta.var.expr.ts keyword.operator.ternary.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                         source.ts meta.var.expr.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                          source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                            ^^^^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                                           source.ts meta.var.expr.ts string.quoted.single.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                               source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                                 ^
                                                 source.ts punctuation.terminator.statement.ts
 >

--- a/tests/baselines/Issue124.txt
+++ b/tests/baselines/Issue124.txt
@@ -27,63 +27,63 @@ Grammar: TypeScript.tmLanguage
 >
 >let a = true ? true : true;  
          ^^^^
-         [6, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts 
+         [6, 9]: source.ts meta.var.expr.ts constant.language.boolean.true.ts 
                 ^^^^
-                [6, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts 
+                [6, 16]: source.ts meta.var.expr.ts constant.language.boolean.true.ts 
                        ^^^^
-                       [6, 23]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts 
+                       [6, 23]: source.ts meta.var.expr.ts constant.language.boolean.true.ts 
 >let b = true ? true : `this is ${} highlighted`
          ^^^^
-         [7, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts 
+         [7, 9]: source.ts meta.var.expr.ts constant.language.boolean.true.ts 
                 ^^^^
-                [7, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts 
+                [7, 16]: source.ts meta.var.expr.ts constant.language.boolean.true.ts 
                        ^
-                       [7, 23]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts 
+                       [7, 23]: source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts 
                         ^^^^^^^^
-                        [7, 24]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts 
+                        [7, 24]: source.ts meta.var.expr.ts string.template.ts 
                                 ^^
-                                [7, 32]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts 
+                                [7, 32]: source.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts 
 >let c = true ? `hello` : `this ${DEPENDENCY_SEPARATOR}${moduleName} is highlighted`;
          ^^^^
-         [8, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts 
+         [8, 9]: source.ts meta.var.expr.ts constant.language.boolean.true.ts 
                 ^
-                [8, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts 
+                [8, 16]: source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts 
                  ^^^^^
-                 [8, 17]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts 
+                 [8, 17]: source.ts meta.var.expr.ts string.template.ts 
                           ^
-                          [8, 26]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts 
+                          [8, 26]: source.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts 
                            ^^^^^
-                           [8, 27]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts 
+                           [8, 27]: source.ts meta.var.expr.ts string.template.ts 
 >
 >var newVar = a ? (b == `hello`) : true;
      ^^^^^^
      [10, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
               ^
-              [10, 14]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
+              [10, 14]: source.ts meta.var.expr.ts variable.other.readwrite.ts 
                 ^
-                [10, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts 
+                [10, 16]: source.ts meta.var.expr.ts keyword.operator.ternary.ts 
                   ^
-                  [10, 18]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts 
+                  [10, 18]: source.ts meta.var.expr.ts meta.brace.round.ts 
                                    ^^^^
-                                   [10, 35]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts 
+                                   [10, 35]: source.ts meta.var.expr.ts constant.language.boolean.true.ts 
 >
 >var debArch = arch === 'x64' ? 'amd64' : 'i386';
      ^^^^^^^
      [12, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
                ^^^^
-               [12, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
+               [12, 15]: source.ts meta.var.expr.ts variable.other.readwrite.ts 
                     ^^^
-                    [12, 20]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.comparison.ts 
+                    [12, 20]: source.ts meta.var.expr.ts keyword.operator.comparison.ts 
                         ^
-                        [12, 24]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
+                        [12, 24]: source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
                               ^
-                              [12, 30]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts 
+                              [12, 30]: source.ts meta.var.expr.ts keyword.operator.ternary.ts 
                                 ^
-                                [12, 32]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
+                                [12, 32]: source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
                                         ^
-                                        [12, 40]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts 
+                                        [12, 40]: source.ts meta.var.expr.ts keyword.operator.ternary.ts 
                                           ^
-                                          [12, 42]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
+                                          [12, 42]: source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
 >
 >/*
 >	Comment

--- a/tests/baselines/Issue133.baseline.txt
+++ b/tests/baselines/Issue133.baseline.txt
@@ -23,7 +23,7 @@ Grammar: TypeScript.tmLanguage
               source.ts meta.class.ts
 >  $fieldName: string;
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^^^^^^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^
@@ -38,7 +38,7 @@ Grammar: TypeScript.tmLanguage
                       source.ts meta.class.ts
 >  $getFieldViewCtrl: () => FieldView;
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^^^^^^^^^^^^^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                     ^

--- a/tests/baselines/Issue142.baseline.txt
+++ b/tests/baselines/Issue142.baseline.txt
@@ -24,7 +24,7 @@ Grammar: TypeScript.tmLanguage
           source.ts meta.class.ts
 >  abc = () =>
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
       ^

--- a/tests/baselines/Issue143.baseline.txt
+++ b/tests/baselines/Issue143.baseline.txt
@@ -105,7 +105,7 @@ Grammar: TypeScript.tmLanguage
                     source.ts meta.class.ts
 >  numberOfClicks = 0;
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^^^^^^^^^^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                  ^

--- a/tests/baselines/Issue153.baseline.txt
+++ b/tests/baselines/Issue153.baseline.txt
@@ -148,7 +148,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -169,7 +169,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -190,7 +190,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -211,7 +211,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -232,7 +232,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -253,7 +253,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -274,7 +274,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -295,7 +295,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -316,7 +316,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^

--- a/tests/baselines/Issue157.baseline.txt
+++ b/tests/baselines/Issue157.baseline.txt
@@ -16,49 +16,49 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+               source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                  source.ts meta.var.expr.ts new.expr.ts
                    ^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                   source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                      source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                        ^^^^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                       source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                             source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                              source.ts meta.var.expr.ts meta.brace.round.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                               source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+                                source.ts meta.var.expr.ts meta.array.literal.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                 source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                   ^^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts
+                                  source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
+                                      source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+                                       source.ts meta.var.expr.ts meta.array.literal.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                        source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                          ^^^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts
+                                         source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                            source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+                                             source.ts meta.var.expr.ts meta.array.literal.ts
                                               ^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                                              source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                               source.ts meta.var.expr.ts meta.brace.round.ts
                                                 ^
                                                 source.ts punctuation.terminator.statement.ts
                                                  ^^

--- a/tests/baselines/Issue158.baseline.txt
+++ b/tests/baselines/Issue158.baseline.txt
@@ -69,9 +69,9 @@ Grammar: TypeScript.tmLanguage
                   ^^
                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                     ^
-                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                      ^
-                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                       ^
                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
                        ^

--- a/tests/baselines/Issue163.baseline.txt
+++ b/tests/baselines/Issue163.baseline.txt
@@ -19,44 +19,44 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.var.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+           source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
             ^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts
 >    async f() {
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^^^^^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts storage.modifier.async.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts storage.modifier.async.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts
+          source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
+           source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+               source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
 >
  ^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
 >    }
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
       ^^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+      source.ts meta.var.expr.ts meta.object-literal.ts
 >};
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
   ^
   source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue171.baseline.txt
+++ b/tests/baselines/Issue171.baseline.txt
@@ -74,7 +74,7 @@ Grammar: TypeScript.tmLanguage
                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
 >            stringContent: string;
  ^^^^^^^^^^^^
- source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
              ^^^^^^^^^^^^^
              source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                           ^
@@ -89,7 +89,7 @@ Grammar: TypeScript.tmLanguage
                                    source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
 >            minLength: number;
  ^^^^^^^^^^^^
- source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
              ^^^^^^^^^
              source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                       ^
@@ -104,7 +104,7 @@ Grammar: TypeScript.tmLanguage
                                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
 >            maxLength: number,
  ^^^^^^^^^^^^
- source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
              ^^^^^^^^^
              source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                       ^
@@ -119,7 +119,7 @@ Grammar: TypeScript.tmLanguage
                                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
 >            validationErrorMessage: string
  ^^^^^^^^^^^^
- source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
              ^^^^^^^^^^^^^^^^^^^^^^
              source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                    ^
@@ -159,7 +159,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^^
      source.ts meta.class.ts storage.modifier.ts
             ^
-            source.ts meta.class.ts meta.field.declaration.ts
+            source.ts meta.class.ts
              ^
              source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
               ^
@@ -196,7 +196,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^^
      source.ts meta.class.ts storage.modifier.ts
             ^
-            source.ts meta.class.ts meta.field.declaration.ts
+            source.ts meta.class.ts
              ^^^^^^^^^^^^^^^^^^^
              source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                 ^

--- a/tests/baselines/Issue172.baseline.txt
+++ b/tests/baselines/Issue172.baseline.txt
@@ -16,29 +16,29 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.modifier.async.ts
+         source.ts meta.var.expr.ts meta.arrow.ts storage.modifier.async.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+              source.ts meta.var.expr.ts meta.arrow.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+               source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+                source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                 source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                  source.ts meta.var.expr.ts meta.arrow.ts
                    ^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                   source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                     source.ts meta.var.expr.ts meta.arrow.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                      source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                       source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                         ^
                         source.ts punctuation.terminator.statement.ts
                          ^^
@@ -53,26 +53,26 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+        source.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+         source.ts meta.var.expr.ts
           ^^^^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts storage.modifier.async.ts
+          source.ts meta.var.expr.ts meta.function.ts storage.modifier.async.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts
+               source.ts meta.var.expr.ts meta.function.ts
                 ^^^^^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts storage.type.function.ts
+                source.ts meta.var.expr.ts meta.function.ts storage.type.function.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                        source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
+                         source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                          source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts
+                           source.ts meta.var.expr.ts meta.function.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                            source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                             source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
                               ^
                               source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue175.baseline.txt
+++ b/tests/baselines/Issue175.baseline.txt
@@ -17,13 +17,13 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+         source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+          source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
            ^
            source.ts punctuation.terminator.statement.ts
             ^^
@@ -38,13 +38,13 @@ Grammar: TypeScript.tmLanguage
          ^
          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+          source.ts meta.var.expr.ts keyword.operator.assignment.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.var.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+            source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+             source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
               ^
               source.ts punctuation.terminator.statement.ts
                ^^

--- a/tests/baselines/Issue177.baseline.txt
+++ b/tests/baselines/Issue177.baseline.txt
@@ -8,11 +8,11 @@ Grammar: TypeScript.tmLanguage
 -----------------------------------
 >() => (/s/);
  ^
- source.ts meta.brace.round.ts
+ source.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
   ^
-  source.ts meta.brace.round.ts
+  source.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
    ^
-   source.ts
+   source.ts meta.arrow.ts
     ^^
     source.ts meta.arrow.ts storage.type.function.arrow.ts
       ^
@@ -33,11 +33,11 @@ Grammar: TypeScript.tmLanguage
              source.ts
 >() => /s/;
  ^
- source.ts meta.brace.round.ts
+ source.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
   ^
-  source.ts meta.brace.round.ts
+  source.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
    ^
-   source.ts
+   source.ts meta.arrow.ts
     ^^
     source.ts meta.arrow.ts storage.type.function.arrow.ts
       ^

--- a/tests/baselines/Issue178.baseline.txt
+++ b/tests/baselines/Issue178.baseline.txt
@@ -27,7 +27,7 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.brace.square.ts
              ^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.indexer.parameter.ts variable.parameter.ts
+             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts variable.parameter.ts
                 ^
                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                  ^
@@ -86,7 +86,7 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.brace.square.ts
              ^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.indexer.parameter.ts variable.parameter.ts
+             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts variable.parameter.ts
                 ^
                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                  ^

--- a/tests/baselines/Issue178.baseline.txt
+++ b/tests/baselines/Issue178.baseline.txt
@@ -59,11 +59,11 @@ Grammar: TypeScript.tmLanguage
                                          ^
                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                          source.ts meta.var.expr.ts keyword.operator.assignment.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                           source.ts meta.var.expr.ts
                                             ^^^^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.null.ts
+                                            source.ts meta.var.expr.ts constant.language.null.ts
                                                 ^
                                                 source.ts punctuation.terminator.statement.ts
                                                  ^^
@@ -128,11 +128,11 @@ Grammar: TypeScript.tmLanguage
                                                    ^
                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                                                     ^
-                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                                    source.ts meta.var.expr.ts keyword.operator.assignment.ts
                                                      ^
-                                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                     source.ts meta.var.expr.ts
                                                       ^^^^
-                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.null.ts
+                                                      source.ts meta.var.expr.ts constant.language.null.ts
                                                           ^
                                                           source.ts punctuation.terminator.statement.ts
                                                            ^^
@@ -147,15 +147,15 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.var.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+           source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
             ^^^^^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+            source.ts meta.var.expr.ts string.quoted.double.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                    ^
                    source.ts punctuation.terminator.statement.ts
                     ^^
@@ -170,11 +170,11 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.var.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+           source.ts meta.var.expr.ts constant.numeric.decimal.ts
             ^
             source.ts punctuation.terminator.statement.ts
              ^^
@@ -195,10 +195,10 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.null.ts
+                source.ts meta.var.expr.ts constant.language.null.ts
                     ^
                     source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue180.baseline.txt
+++ b/tests/baselines/Issue180.baseline.txt
@@ -76,19 +76,19 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.block.ts meta.var.expr.ts
              ^^^^^^^^^
-             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+             source.ts meta.block.ts meta.var.expr.ts variable.other.object.ts
                       ^
-                      source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                      source.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                        ^^^^^^^^^^^
-                       source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.property.ts
+                       source.ts meta.block.ts meta.var.expr.ts variable.other.object.property.ts
                                   ^
-                                  source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                  source.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                                    ^
-                                   source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.property.ts
+                                   source.ts meta.block.ts meta.var.expr.ts variable.other.property.ts
                                     ^
                                     source.ts meta.block.ts punctuation.terminator.statement.ts
                                      ^^

--- a/tests/baselines/Issue183.baseline.txt
+++ b/tests/baselines/Issue183.baseline.txt
@@ -70,7 +70,7 @@ Grammar: TypeScript.tmLanguage
  source.ts meta.class.ts
 >    callback = (): void =>
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^^^^^^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^

--- a/tests/baselines/Issue186.baseline.txt
+++ b/tests/baselines/Issue186.baseline.txt
@@ -67,45 +67,45 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts
            ^
-           source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+           source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
             ^^^^^^
-            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                   ^
-                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                    ^
-                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts
                     ^^
-                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                       ^
-                      source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                      source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts
                        ^
-                       source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                       source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
 >    console.log(param1);
  ^^^^
- source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+ source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
      ^^^^^^^
-     source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts support.class.console.ts
+     source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts support.class.console.ts
             ^
-            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
+            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
              ^^^
-             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts support.function.console.ts
+             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts support.function.console.ts
                 ^
-                source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
+                source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
                  ^^^^^^
-                 source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts variable.other.readwrite.ts
+                 source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts variable.other.readwrite.ts
                        ^
-                       source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
+                       source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
                         ^
-                        source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.terminator.statement.ts
+                        source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.terminator.statement.ts
 >  }
  ^^
- source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+ source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
    ^
-   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
 >  console.log(param1);
  ^^
  source.ts meta.function.ts meta.block.ts
@@ -194,27 +194,27 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.function.ts meta.block.ts meta.var.expr.ts
            ^^^^^^
-           source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+           source.ts meta.function.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts
                  ^
-                 source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                   ^
-                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.ternary.ts
                    ^
-                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                     ^
-                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                      ^
-                     source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                     source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                       ^
-                      source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                      source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.ternary.ts
                        ^
-                       source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                         ^^^^^^
-                        source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                        source.ts meta.function.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts
                               ^
                               source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
 >}

--- a/tests/baselines/Issue187.baseline.txt
+++ b/tests/baselines/Issue187.baseline.txt
@@ -19,51 +19,51 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^^^^^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts support.type.object.module.ts
+              source.ts meta.var.expr.ts support.type.object.module.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                    source.ts meta.var.expr.ts punctuation.accessor.ts
                      ^^^^^^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts support.type.object.module.ts
+                     source.ts meta.var.expr.ts support.type.object.module.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                            source.ts meta.var.expr.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^^^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts variable.parameter.ts
+                               source.ts meta.var.expr.ts meta.arrow.ts variable.parameter.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                  source.ts meta.var.expr.ts meta.arrow.ts
                                    ^^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                   source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                     source.ts meta.var.expr.ts meta.arrow.ts
                                       ^^^^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+                                      source.ts meta.var.expr.ts variable.other.object.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                          source.ts meta.var.expr.ts punctuation.accessor.ts
                                            ^^^^^^^^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                                           source.ts meta.var.expr.ts entity.name.function.ts
                                                    ^
-                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                   source.ts meta.var.expr.ts meta.brace.round.ts
                                                     ^^^^
-                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+                                                    source.ts meta.var.expr.ts variable.other.object.ts
                                                         ^
-                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                                        source.ts meta.var.expr.ts punctuation.accessor.ts
                                                          ^^^^^^^
-                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                                                         source.ts meta.var.expr.ts entity.name.function.ts
                                                                 ^
-                                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                source.ts meta.var.expr.ts meta.brace.round.ts
                                                                  ^^^
-                                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                                                                 source.ts meta.var.expr.ts variable.other.readwrite.ts
                                                                     ^
-                                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                    source.ts meta.var.expr.ts meta.brace.round.ts
                                                                      ^
-                                                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                     source.ts meta.var.expr.ts meta.brace.round.ts
                                                                       ^
                                                                       source.ts punctuation.terminator.statement.ts
                                                                        ^^
@@ -81,68 +81,68 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^^^^^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts support.type.object.module.ts
+              source.ts meta.var.expr.ts support.type.object.module.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                    source.ts meta.var.expr.ts punctuation.accessor.ts
                      ^^^^^^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts support.type.object.module.ts
+                     source.ts meta.var.expr.ts support.type.object.module.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                            source.ts meta.var.expr.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                             source.ts meta.var.expr.ts keyword.operator.assignment.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.var.expr.ts
                                ^^^^^^^^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts storage.type.function.ts
+                               source.ts meta.var.expr.ts meta.function.ts storage.type.function.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                                       source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                         ^^^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
+                                        source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                           source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts
+                                            source.ts meta.var.expr.ts meta.function.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                                             source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
                                               ^^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+                                              source.ts meta.var.expr.ts meta.function.ts meta.block.ts
 >    return  trim.trailing(trim.leading(str));
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.function.ts meta.block.ts
      ^^^^^^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts keyword.control.flow.ts
+     source.ts meta.var.expr.ts meta.function.ts meta.block.ts keyword.control.flow.ts
            ^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+           source.ts meta.var.expr.ts meta.function.ts meta.block.ts
              ^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts variable.other.object.ts
+             source.ts meta.var.expr.ts meta.function.ts meta.block.ts variable.other.object.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.accessor.ts
+                 source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.accessor.ts
                   ^^^^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts entity.name.function.ts
+                  source.ts meta.var.expr.ts meta.function.ts meta.block.ts entity.name.function.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
+                          source.ts meta.var.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
                            ^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts variable.other.object.ts
+                           source.ts meta.var.expr.ts meta.function.ts meta.block.ts variable.other.object.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.accessor.ts
+                               source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.accessor.ts
                                 ^^^^^^^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts entity.name.function.ts
+                                source.ts meta.var.expr.ts meta.function.ts meta.block.ts entity.name.function.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
+                                       source.ts meta.var.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
                                         ^^^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts variable.other.readwrite.ts
+                                        source.ts meta.var.expr.ts meta.function.ts meta.block.ts variable.other.readwrite.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
+                                           source.ts meta.var.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
+                                            source.ts meta.var.expr.ts meta.function.ts meta.block.ts meta.brace.round.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
+                                             source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                                               ^^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+                                              source.ts meta.var.expr.ts meta.function.ts meta.block.ts
 >}
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts

--- a/tests/baselines/Issue191.baseline.txt
+++ b/tests/baselines/Issue191.baseline.txt
@@ -70,25 +70,25 @@ Grammar: TypeScript.tmLanguage
                  ^
                  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                   ^
-                  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                    ^
-                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
                     ^
-                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.other.object.ts
+                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts constant.other.object.ts
                      ^
-                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                       ^^^^^
-                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts entity.name.function.ts
                            ^
-                           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                             ^^^^^^^
-                            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                    ^
-                                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                                     ^
-                                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                      ^
-                                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                       ^
                                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
 >        this.store = new Data();
@@ -278,25 +278,25 @@ Grammar: TypeScript.tmLanguage
                  ^
                  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                   ^
-                  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                    ^
-                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
                     ^
-                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.other.object.ts
+                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts constant.other.object.ts
                      ^
-                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                       ^^^^^
-                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts entity.name.function.ts
                            ^
-                           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                             ^^^^^^^
-                            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                    ^
-                                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                                     ^
-                                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                      ^
-                                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                       ^
                                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
 >        this.store = new Data();

--- a/tests/baselines/Issue191.txt
+++ b/tests/baselines/Issue191.txt
@@ -38,9 +38,9 @@ Grammar: TypeScript.tmLanguage
              ^^^^
              [3, 13]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
                             ^^^^^^^
-                            [3, 28]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                            [3, 28]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts 
                                      ^
-                                     [3, 37]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts 
+                                     [3, 37]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts 
 >        this.store = new Data();
          ^^^^
          [4, 9]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts variable.language.this.ts 
@@ -82,9 +82,9 @@ Grammar: TypeScript.tmLanguage
              ^^^^
              [13, 13]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
                             ^^^^^^^
-                            [13, 28]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                            [13, 28]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts 
                                      ^
-                                     [13, 37]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts 
+                                     [13, 37]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts 
 >        this.store = new Data();
          ^^^^
          [14, 9]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts variable.language.this.ts 

--- a/tests/baselines/Issue193.baseline.txt
+++ b/tests/baselines/Issue193.baseline.txt
@@ -94,15 +94,15 @@ Grammar: TypeScript.tmLanguage
          ^
          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+          source.ts meta.var.expr.ts keyword.operator.assignment.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.var.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+            source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
              ^^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+             source.ts meta.var.expr.ts string.quoted.double.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                   source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                     ^
                     source.ts punctuation.terminator.statement.ts
                      ^^
@@ -117,14 +117,14 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+               source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                 ^^^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                source.ts meta.var.expr.ts string.quoted.double.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                      source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                        ^
                        source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue197.baseline.txt
+++ b/tests/baselines/Issue197.baseline.txt
@@ -43,7 +43,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.class.ts
                 ^^^^^^^^^^^^^^^^^
                 source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                  ^
@@ -92,7 +92,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.class.ts
                 ^^^^^^^^^^^^^^^^
                 source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                 ^
@@ -117,7 +117,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.class.ts
                 ^^^^^^^^^^^^^^^^^^^^
                 source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                     ^
@@ -142,7 +142,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.class.ts
                 ^^^^^^^^^^^^^^^^^^^^^
                 source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                      ^
@@ -264,7 +264,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.class.ts
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                                ^
@@ -289,7 +289,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.class.ts
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                 source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                              ^
@@ -314,7 +314,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.class.ts
                 ^^^^^^^^^^^^^^^^
                 source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                                 ^

--- a/tests/baselines/Issue198.baseline.txt
+++ b/tests/baselines/Issue198.baseline.txt
@@ -20,11 +20,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
           ^
           source.ts meta.var.expr.ts punctuation.separator.comma.ts
            ^
@@ -34,11 +34,11 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
                  ^
                  source.ts meta.var.expr.ts punctuation.separator.comma.ts
                   ^
@@ -48,11 +48,11 @@ Grammar: TypeScript.tmLanguage
                     ^
                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                     source.ts meta.var.expr.ts keyword.operator.assignment.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                      source.ts meta.var.expr.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                       source.ts meta.var.expr.ts constant.numeric.decimal.ts
                         ^
                         source.ts punctuation.terminator.statement.ts
                          ^^
@@ -67,21 +67,21 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+             source.ts meta.var.expr.ts variable.other.readwrite.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+               source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                 source.ts meta.var.expr.ts variable.other.readwrite.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                  source.ts meta.var.expr.ts
 >    / c;
  ^^^^
  source.ts
@@ -105,21 +105,21 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+              source.ts meta.var.expr.ts variable.other.readwrite.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.var.expr.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                  source.ts meta.var.expr.ts variable.other.readwrite.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                   source.ts meta.var.expr.ts
 >    / c * a + b / a / b / c;
  ^^^^
  source.ts
@@ -183,66 +183,66 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+              source.ts meta.var.expr.ts variable.other.readwrite.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.var.expr.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                  source.ts meta.var.expr.ts variable.other.readwrite.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                   source.ts meta.var.expr.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                    source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                     source.ts meta.var.expr.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                      source.ts meta.var.expr.ts variable.other.readwrite.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.var.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                        source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                          source.ts meta.var.expr.ts variable.other.readwrite.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                           source.ts meta.var.expr.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                            source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                             source.ts meta.var.expr.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                              source.ts meta.var.expr.ts variable.other.readwrite.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                               source.ts meta.var.expr.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                                source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                 source.ts meta.var.expr.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                                  source.ts meta.var.expr.ts variable.other.readwrite.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                   source.ts meta.var.expr.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                                    source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                     source.ts meta.var.expr.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                                      source.ts meta.var.expr.ts variable.other.readwrite.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                       source.ts meta.var.expr.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                                        source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                         source.ts meta.var.expr.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                                          source.ts meta.var.expr.ts variable.other.readwrite.ts
                                            ^
                                            source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue202.baseline.txt
+++ b/tests/baselines/Issue202.baseline.txt
@@ -35,7 +35,7 @@ Grammar: TypeScriptReact.tmLanguage
                     source.tsx meta.class.tsx
 >    test: T;
  ^^^^
- source.tsx meta.class.tsx meta.field.declaration.tsx
+ source.tsx meta.class.tsx
      ^^^^
      source.tsx meta.class.tsx meta.field.declaration.tsx variable.object.property.tsx
          ^
@@ -71,7 +71,7 @@ Grammar: TypeScriptReact.tmLanguage
                   source.tsx meta.class.tsx
 >    prop: Test<T>;
  ^^^^
- source.tsx meta.class.tsx meta.field.declaration.tsx
+ source.tsx meta.class.tsx
      ^^^^
      source.tsx meta.class.tsx meta.field.declaration.tsx variable.object.property.tsx
          ^

--- a/tests/baselines/Issue203.baseline.txt
+++ b/tests/baselines/Issue203.baseline.txt
@@ -22,29 +22,29 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
         ^
-        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+        source.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+         source.ts meta.var.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+          source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
            ^^^^
-           source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts
+           source.ts meta.var.expr.ts string.quoted.single.ts
                ^
-               source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+               source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                 ^
-                source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts punctuation.accessor.ts
+                source.ts meta.var.expr.ts punctuation.accessor.ts
                  ^^^^^^^
-                 source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts support.function.ts
+                 source.ts meta.var.expr.ts support.function.ts
                         ^
-                        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                        source.ts meta.var.expr.ts meta.brace.round.ts
                          ^
-                         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                         source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                           ^^^^
-                          source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts
+                          source.ts meta.var.expr.ts string.quoted.single.ts
                               ^
-                              source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                              source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                ^
-                               source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                               source.ts meta.var.expr.ts meta.brace.round.ts
                                 ^
                                 source.ts punctuation.terminator.statement.ts
                                  ^^
@@ -85,29 +85,29 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
         ^
-        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+        source.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+         source.ts meta.var.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+          source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
            ^^^^
-           source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts
+           source.ts meta.var.expr.ts string.quoted.single.ts
                ^
-               source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+               source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                 ^
-                source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts punctuation.accessor.ts
+                source.ts meta.var.expr.ts punctuation.accessor.ts
                  ^^^^^^^
-                 source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts support.function.ts
+                 source.ts meta.var.expr.ts support.function.ts
                         ^
-                        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                        source.ts meta.var.expr.ts meta.brace.round.ts
                          ^
-                         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                         source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                           ^^^^^^
-                          source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts
+                          source.ts meta.var.expr.ts string.quoted.single.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                                 source.ts meta.var.expr.ts meta.brace.round.ts
                                   ^
                                   source.ts punctuation.terminator.statement.ts
                                    ^^

--- a/tests/baselines/Issue208.baseline.txt
+++ b/tests/baselines/Issue208.baseline.txt
@@ -116,7 +116,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^^^^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                     ^
@@ -161,7 +161,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^^^^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                     ^
@@ -201,7 +201,7 @@ Grammar: TypeScript.tmLanguage
  source.ts meta.class.ts
 >    someProp = new Thing<number, string>('data');
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^^^^^^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^
@@ -242,7 +242,7 @@ Grammar: TypeScript.tmLanguage
                                                  source.ts meta.class.ts punctuation.terminator.statement.ts
 >    someProp = makeThing<number, string>('data');
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^^^^^^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^

--- a/tests/baselines/Issue208.baseline.txt
+++ b/tests/baselines/Issue208.baseline.txt
@@ -24,37 +24,37 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+               source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                  source.ts meta.var.expr.ts new.expr.ts
                    ^^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                   source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                        source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                          ^^^^^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                         source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
+                               source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts
+                                source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts
                                  ^^^^^^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                 source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                       source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                        source.ts meta.var.expr.ts meta.brace.round.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                         source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                           ^^^^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                                          source.ts meta.var.expr.ts string.quoted.single.ts
                                               ^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                              source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                               source.ts meta.var.expr.ts meta.brace.round.ts
                                                 ^
                                                 source.ts punctuation.terminator.statement.ts
 >var someVar = makeThing<number, string>('data');
@@ -67,33 +67,33 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^^^^^^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+               source.ts meta.var.expr.ts entity.name.function.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                        source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                          ^^^^^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                         source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
+                               source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts
+                                source.ts meta.var.expr.ts meta.type.parameters.ts
                                  ^^^^^^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                 source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                       source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                        source.ts meta.var.expr.ts meta.brace.round.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                         source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                           ^^^^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                                          source.ts meta.var.expr.ts string.quoted.single.ts
                                               ^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                              source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                               source.ts meta.var.expr.ts meta.brace.round.ts
                                                 ^
                                                 source.ts punctuation.terminator.statement.ts
 >

--- a/tests/baselines/Issue208.txt
+++ b/tests/baselines/Issue208.txt
@@ -16,28 +16,28 @@ Grammar: TypeScript.tmLanguage
 -----------------------------------
 >var someVar = new Thing<number, string>('data');
                ^^^
-               [1, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts 
+               [1, 15]: source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts 
                    ^^^^^
-                   [1, 19]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts 
+                   [1, 19]: source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts 
                          ^^^^^^
-                         [1, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                         [1, 25]: source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts 
                                  ^^^^^^
-                                 [1, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                                 [1, 33]: source.ts meta.var.expr.ts new.expr.ts meta.type.parameters.ts support.type.primitive.ts 
                                           ^^^^
-                                          [1, 42]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+                                          [1, 42]: source.ts meta.var.expr.ts string.quoted.single.ts 
                                                ^
-                                               [1, 47]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts 
+                                               [1, 47]: source.ts meta.var.expr.ts meta.brace.round.ts 
 >var someVar = makeThing<number, string>('data');
                ^^^^^^^^^
-               [2, 15]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts 
+               [2, 15]: source.ts meta.var.expr.ts entity.name.function.ts 
                          ^^^^^^
-                         [2, 25]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                         [2, 25]: source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts 
                                  ^^^^^^
-                                 [2, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                                 [2, 33]: source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts 
                                           ^^^^
-                                          [2, 42]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+                                          [2, 42]: source.ts meta.var.expr.ts string.quoted.single.ts 
                                                ^
-                                               [2, 47]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts 
+                                               [2, 47]: source.ts meta.var.expr.ts meta.brace.round.ts 
 >
 >class MyClass {
 >    static someProp = new Thing<number, string>('data');

--- a/tests/baselines/Issue212.baseline.txt
+++ b/tests/baselines/Issue212.baseline.txt
@@ -23,11 +23,11 @@ Grammar: TypeScript.tmLanguage
          ^
          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+          source.ts meta.var.expr.ts keyword.operator.assignment.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.var.expr.ts
             ^^^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+            source.ts meta.var.expr.ts variable.other.readwrite.ts
                 ^
                 source.ts punctuation.terminator.statement.ts
                  ^^

--- a/tests/baselines/Issue215.baseline.txt
+++ b/tests/baselines/Issue215.baseline.txt
@@ -46,11 +46,11 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                ^
-               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.function.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                  ^
-                 source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                   ^
                   source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                    ^
@@ -111,11 +111,11 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+            source.ts meta.var.expr.ts constant.numeric.decimal.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
               source.ts punctuation.terminator.statement.ts
                ^

--- a/tests/baselines/Issue216.baseline.txt
+++ b/tests/baselines/Issue216.baseline.txt
@@ -84,11 +84,11 @@ Grammar: TypeScript.tmLanguage
                   ^
                   source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                    ^
-                   source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                   source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                     ^
-                    source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                    source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                      ^
-                     source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                     source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                       ^
                       source.ts meta.class.ts meta.field.declaration.ts meta.arrow.ts meta.block.ts punctuation.terminator.statement.ts
                        ^^

--- a/tests/baselines/Issue216.baseline.txt
+++ b/tests/baselines/Issue216.baseline.txt
@@ -33,7 +33,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^^^^^^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                       ^

--- a/tests/baselines/Issue217.baseline.txt
+++ b/tests/baselines/Issue217.baseline.txt
@@ -42,7 +42,7 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.class.ts meta.decorator.ts meta.brace.round.ts
             ^
-            source.ts meta.class.ts meta.field.declaration.ts
+            source.ts meta.class.ts
              ^^^^^^
              source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                    ^
@@ -65,7 +65,7 @@ Grammar: TypeScript.tmLanguage
                                         source.ts meta.class.ts meta.field.declaration.ts
 >  statuses = ["started", "completed"]
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^^^^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
            ^
@@ -133,7 +133,7 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.class.ts meta.decorator.ts meta.brace.round.ts
             ^
-            source.ts meta.class.ts meta.field.declaration.ts
+            source.ts meta.class.ts
              ^^^^^^
              source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                    ^
@@ -158,7 +158,7 @@ Grammar: TypeScript.tmLanguage
                                          source.ts meta.class.ts
 >  statuses = ["started", "completed"]
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^^^^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
            ^

--- a/tests/baselines/Issue219.baseline.txt
+++ b/tests/baselines/Issue219.baseline.txt
@@ -41,17 +41,17 @@ Grammar: TypeScript.tmLanguage
   ^
   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
    ^
-   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+   source.ts meta.var.expr.ts keyword.operator.assignment.ts
     ^
-    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+    source.ts meta.var.expr.ts
      ^^^^
-     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.language.this.ts
+     source.ts meta.var.expr.ts variable.language.this.ts
          ^
-         source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.accessor.ts
+         source.ts meta.var.expr.ts punctuation.accessor.ts
           ^^^^^
-          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.other.property.ts
+          source.ts meta.var.expr.ts variable.other.property.ts
                ^
-               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+               source.ts meta.var.expr.ts
 >if (!map) return;
  ^^
  source.ts keyword.control.conditional.ts

--- a/tests/baselines/Issue221.baseline.txt
+++ b/tests/baselines/Issue221.baseline.txt
@@ -96,11 +96,11 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
                  ^
-                 source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                 source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                   ^
                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
                    ^^

--- a/tests/baselines/Issue221.baseline.txt
+++ b/tests/baselines/Issue221.baseline.txt
@@ -32,7 +32,7 @@ Grammar: TypeScript.tmLanguage
  source.ts meta.class.ts
 >    variable = 
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^^^^^^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^

--- a/tests/baselines/Issue226.baseline.txt
+++ b/tests/baselines/Issue226.baseline.txt
@@ -47,26 +47,26 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.var.expr.ts
            ^^^^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.modifier.async.ts
+           source.ts meta.var.expr.ts meta.arrow.ts storage.modifier.async.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                source.ts meta.var.expr.ts meta.arrow.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                 source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                  source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                   source.ts meta.var.expr.ts meta.arrow.ts
                     ^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                    source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                      source.ts meta.var.expr.ts meta.arrow.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                       source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+                        source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                         source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts

--- a/tests/baselines/Issue230.baseline.txt
+++ b/tests/baselines/Issue230.baseline.txt
@@ -142,105 +142,105 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                  ^^^^^
-                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts variable.other.object.ts
                       ^
-                      source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                      source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                        ^^^^
-                       source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.property.ts
+                       source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts variable.other.property.ts
                            ^
-                           source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                           source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                             ^^
-                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.logical.ts
+                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts keyword.operator.logical.ts
                               ^
-                              source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                              source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                                ^
-                               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                 ^^^^^
-                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts variable.other.object.ts
                                      ^
-                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                                       ^^^
-                                      source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.property.ts
+                                      source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts variable.other.property.ts
                                          ^
-                                         source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                         source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                           ^
-                                          source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                          source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                                            ^
-                                           source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                                           source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts keyword.operator.ternary.ts
                                             ^
-                                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                                              ^^^^^^
-                                             source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                                             source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts entity.name.function.ts
                                                    ^
-                                                   source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                   source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                                     ^
-                                                    source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
+                                                    source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.begin.ts
                                                      ^^
-                                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
+                                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
                                                        ^^^^^
-                                                       source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts variable.other.object.ts
+                                                       source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts variable.other.object.ts
                                                             ^
-                                                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.accessor.ts
+                                                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.accessor.ts
                                                              ^^^
-                                                             source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts variable.other.property.ts
+                                                             source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts variable.other.property.ts
                                                                 ^
-                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
+                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
                                                                  ^
-                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts
+                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts
                                                                   ^^
-                                                                  source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
+                                                                  source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.begin.ts
                                                                     ^^^^^
-                                                                    source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts variable.other.object.ts
+                                                                    source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts variable.other.object.ts
                                                                          ^
-                                                                         source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.accessor.ts
+                                                                         source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.accessor.ts
                                                                           ^^^^
-                                                                          source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts variable.other.property.ts
+                                                                          source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts variable.other.property.ts
                                                                               ^
-                                                                              source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
+                                                                              source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts meta.template.expression.ts punctuation.definition.template-expression.end.ts
                                                                                ^
-                                                                               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.template.ts punctuation.definition.string.template.end.ts
+                                                                               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.template.ts punctuation.definition.string.template.end.ts
                                                                                 ^
-                                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.separator.comma.ts
+                                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts punctuation.separator.comma.ts
                                                                                  ^
-                                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                                                                                   ^
-                                                                                  source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                                                                  source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                                                                    ^^^^^^^^^^^^^^^^
-                                                                                   source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                                                                   source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts
                                                                                                    ^
-                                                                                                   source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                                                                                   source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                                                                                     ^
-                                                                                                    source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                                                    source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                                                                                      ^
-                                                                                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                                                                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                                                                                                       ^^^^^^
-                                                                                                      source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                                                                                                      source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts entity.name.function.ts
                                                                                                             ^
-                                                                                                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                                                            source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                                                                                              ^
-                                                                                                             source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                                                             source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                                                                                               ^
-                                                                                                              source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                                                                              source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                                                                                                                ^
-                                                                                                               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.ternary.ts
+                                                                                                               source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts keyword.operator.ternary.ts
                                                                                                                 ^
-                                                                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts
                                                                                                                  ^^^^^^^^^
-                                                                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                                                                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts entity.name.function.ts
                                                                                                                           ^
-                                                                                                                          source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                                                                          source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                                                                                                            ^^^^^
-                                                                                                                           source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+                                                                                                                           source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts variable.other.object.ts
                                                                                                                                 ^
-                                                                                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                                                                                                                source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                                                                                                                                  ^^^^
-                                                                                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.property.ts
+                                                                                                                                 source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts variable.other.property.ts
                                                                                                                                      ^
-                                                                                                                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                                                                                     source.ts meta.arrow.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                                                                                                                       ^
                                                                                                                                       source.ts meta.arrow.ts meta.block.ts punctuation.terminator.statement.ts
                                                                                                                                        ^^

--- a/tests/baselines/Issue232.baseline.txt
+++ b/tests/baselines/Issue232.baseline.txt
@@ -60,23 +60,23 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                 ^
-                source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                  ^
-                 source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.block.ts meta.var.expr.ts
                   ^^^^^^^^^
-                  source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+                  source.ts meta.block.ts meta.var.expr.ts variable.other.object.ts
                            ^
-                           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                           source.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                             ^^^^
-                            source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.property.ts
+                            source.ts meta.block.ts meta.var.expr.ts variable.other.object.property.ts
                                 ^
-                                source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                source.ts meta.block.ts meta.var.expr.ts punctuation.accessor.ts
                                  ^^^^^^^^^
-                                 source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                                 source.ts meta.block.ts meta.var.expr.ts entity.name.function.ts
                                           ^
-                                          source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                          source.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                            ^
-                                           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                           source.ts meta.block.ts meta.var.expr.ts meta.brace.round.ts
                                             ^
                                             source.ts meta.block.ts punctuation.terminator.statement.ts
                                              ^

--- a/tests/baselines/Issue239.baseline.txt
+++ b/tests/baselines/Issue239.baseline.txt
@@ -23,54 +23,54 @@ Grammar: TypeScriptReact.tmLanguage
             ^
             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+             source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+              source.tsx meta.var.expr.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+               source.tsx meta.var.expr.tsx meta.brace.round.tsx
                 ^^^^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx constant.language.boolean.true.tsx
+                source.tsx meta.var.expr.tsx constant.language.boolean.true.tsx
                     ^
-                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+                    source.tsx meta.var.expr.tsx meta.brace.round.tsx
                      ^
-                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                     source.tsx meta.var.expr.tsx
                       ^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.ternary.tsx
+                      source.tsx meta.var.expr.tsx keyword.operator.ternary.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                       source.tsx meta.var.expr.tsx
                         ^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                          ^
-                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                           ^
-                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                            ^^^^^^^^^^^^
-                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
                                        ^^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                          ^
-                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                           ^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                                            ^
-                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                                           source.tsx meta.var.expr.tsx
                                             ^
-                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.ternary.tsx
+                                            source.tsx meta.var.expr.tsx keyword.operator.ternary.tsx
                                              ^
-                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                                             source.tsx meta.var.expr.tsx
                                               ^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                ^
-                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                                 ^
-                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                                                  ^^^^^^^^^^^^^^^^^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
                                                                   ^^
-                                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                                  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                                     ^
-                                                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                    source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                                                      ^
-                                                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                     source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                                                                       ^
-                                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                                                                      source.tsx meta.var.expr.tsx

--- a/tests/baselines/Issue241.baseline.txt
+++ b/tests/baselines/Issue241.baseline.txt
@@ -311,7 +311,7 @@ Grammar: TypeScript.tmLanguage
                                  ^
                                  source.ts meta.function.ts meta.return.type.ts meta.type.tuple.ts meta.type.function.return.ts meta.object.type.ts punctuation.definition.block.ts
                                   ^
-                                  source.ts meta.function.ts meta.return.type.ts meta.type.tuple.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts
+                                  source.ts meta.function.ts meta.return.type.ts meta.type.tuple.ts meta.type.function.return.ts meta.object.type.ts
                                    ^
                                    source.ts meta.function.ts meta.return.type.ts meta.type.tuple.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                     ^

--- a/tests/baselines/Issue241.baseline.txt
+++ b/tests/baselines/Issue241.baseline.txt
@@ -64,11 +64,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                ^
-               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.function.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                 ^
                 source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                  ^^
@@ -133,11 +133,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                ^
-               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.function.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                 ^
                 source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                  ^^
@@ -192,11 +192,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                ^
-               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.function.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                 ^
                 source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                  ^^
@@ -261,11 +261,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.block.ts meta.var.expr.ts
                ^
-               source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                 ^
                 source.ts meta.block.ts punctuation.terminator.statement.ts
                  ^^
@@ -344,11 +344,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                ^
-               source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.function.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                 ^
                 source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                  ^^

--- a/tests/baselines/Issue243.baseline.txt
+++ b/tests/baselines/Issue243.baseline.txt
@@ -139,13 +139,13 @@ Grammar: TypeScript.tmLanguage
                    ^
                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                    source.ts meta.var.expr.ts keyword.operator.assignment.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                     source.ts meta.var.expr.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                      source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                       source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                         ^
                         source.ts punctuation.terminator.statement.ts
                          ^^
@@ -162,13 +162,13 @@ Grammar: TypeScript.tmLanguage
                        ^
                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                        source.ts meta.var.expr.ts keyword.operator.assignment.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                          source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                           source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                             ^
                             source.ts punctuation.terminator.statement.ts
                              ^^

--- a/tests/baselines/Issue244.baseline.txt
+++ b/tests/baselines/Issue244.baseline.txt
@@ -126,21 +126,21 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^^^^^^^^^^^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                 source.ts meta.var.expr.ts entity.name.function.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                              source.ts meta.var.expr.ts meta.brace.round.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                                source.ts meta.var.expr.ts string.quoted.single.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                 source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                  source.ts meta.var.expr.ts meta.brace.round.ts
                                    ^
                                    source.ts punctuation.terminator.statement.ts
                                     ^^
@@ -155,20 +155,20 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^^^^^^^^^^^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                 source.ts meta.var.expr.ts entity.name.function.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                              source.ts meta.var.expr.ts meta.brace.round.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                               source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                                source.ts meta.var.expr.ts string.quoted.single.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                 source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                  source.ts meta.var.expr.ts meta.brace.round.ts
                                    ^
                                    source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue248.baseline.txt
+++ b/tests/baselines/Issue248.baseline.txt
@@ -55,7 +55,7 @@ Grammar: TypeScript.tmLanguage
            source.ts meta.class.ts
 >    m1 = 1;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
        ^
@@ -155,7 +155,7 @@ Grammar: TypeScript.tmLanguage
            source.ts meta.class.ts
 >    m1 = 1;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
        ^
@@ -255,7 +255,7 @@ Grammar: TypeScript.tmLanguage
            source.ts meta.class.ts
 >    m1 = 1;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
        ^
@@ -355,7 +355,7 @@ Grammar: TypeScript.tmLanguage
            source.ts meta.class.ts
 >    m1 = 1;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
        ^
@@ -455,7 +455,7 @@ Grammar: TypeScript.tmLanguage
            source.ts meta.class.ts
 >    m1 = 1;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
        ^
@@ -555,7 +555,7 @@ Grammar: TypeScript.tmLanguage
            source.ts meta.class.ts
 >    m1 = 1;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
        ^

--- a/tests/baselines/Issue249.baseline.txt
+++ b/tests/baselines/Issue249.baseline.txt
@@ -21,49 +21,49 @@ Grammar: TypeScript.tmLanguage
                        ^
                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                        source.ts meta.var.expr.ts keyword.operator.assignment.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                         source.ts meta.var.expr.ts meta.arrow.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                          source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                            ^^^^^^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+                           source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                       source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+                                        source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
                                          ^^^^^^^^^^^^^^^^^^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                                         source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                                                            ^
-                                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.separator.parameter.ts
+                                                           source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.separator.parameter.ts
                                                             ^
-                                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts
+                                                            source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts
                                                              ^^^^
-                                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+                                                             source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
                                                                  ^
-                                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                                                 source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                                                                   ^^^^^^
-                                                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                                                                  source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
                                                                         ^
-                                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                                                        source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                                                          ^
-                                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                                                         source.ts meta.var.expr.ts meta.arrow.ts
                                                                           ^^
-                                                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                                                          source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                                                                             ^
-                                                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                                                            source.ts meta.var.expr.ts meta.arrow.ts
                                                                              ^
-                                                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                                                                             source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                                                                               ^^
-                                                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+                                                                              source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
 >
  ^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
 >}
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
   ^
-  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+  source.ts meta.var.expr.ts
 >
  ^^
  source.ts

--- a/tests/baselines/Issue250.baseline.txt
+++ b/tests/baselines/Issue250.baseline.txt
@@ -80,7 +80,7 @@ Grammar: TypeScript.tmLanguage
    ^^^^^^
    source.ts meta.class.ts storage.modifier.ts
          ^
-         source.ts meta.class.ts meta.field.declaration.ts
+         source.ts meta.class.ts
           ^^^^^^^^
           source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                   ^

--- a/tests/baselines/Issue250.baseline.txt
+++ b/tests/baselines/Issue250.baseline.txt
@@ -115,15 +115,15 @@ Grammar: TypeScript.tmLanguage
              ^
              source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
               ^
-              source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+              source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                ^
-               source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts
                 ^^^
-                source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+                source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                    ^
-                   source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                   source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts new.expr.ts
                     ^^^^^^^^
-                    source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                    source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                             ^
                             source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                              ^^
@@ -242,9 +242,9 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                 ^
-                source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                  ^
-                 source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts meta.var.expr.ts
 >      type.defineField(DesignID.Fields, new Ordering(new FieldDesign));
  ^^^^^^
  source.ts meta.class.ts meta.field.declaration.ts meta.function.ts meta.block.ts

--- a/tests/baselines/Issue251.baseline.txt
+++ b/tests/baselines/Issue251.baseline.txt
@@ -22,9 +22,9 @@ Grammar: TypeScript.tmLanguage
          ^
          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+          source.ts meta.var.expr.ts keyword.operator.assignment.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+           source.ts meta.var.expr.ts constant.numeric.decimal.ts
             ^
             source.ts punctuation.terminator.statement.ts
              ^
@@ -83,11 +83,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.block.ts meta.var.expr.ts
                ^
-               source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+               source.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                 ^
                 source.ts meta.block.ts punctuation.terminator.statement.ts
                  ^

--- a/tests/baselines/Issue252.baseline.txt
+++ b/tests/baselines/Issue252.baseline.txt
@@ -81,25 +81,25 @@ Grammar: TypeScript.tmLanguage
                                                 ^
                                                 source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                                                  ^
-                                                 source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                                 source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                                                   ^
-                                                  source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                  source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts
                                                    ^
-                                                   source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                                   source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                                     ^
-                                                    source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                                    source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts
                                                      ^
-                                                     source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                                     source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                                       ^
-                                                      source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                      source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts
                                                        ^
-                                                       source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+                                                       source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts keyword.operator.arithmetic.ts
                                                         ^
-                                                        source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                        source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts
                                                          ^^^^
-                                                         source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                                                         source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts
                                                              ^
-                                                             source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                             source.ts meta.function.ts meta.block.ts meta.block.ts meta.var.expr.ts
                                                               ^
                                                               source.ts meta.function.ts meta.block.ts meta.block.ts punctuation.definition.block.ts
                                                                ^^

--- a/tests/baselines/Issue262.baseline.txt
+++ b/tests/baselines/Issue262.baseline.txt
@@ -25,11 +25,11 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+              source.ts meta.var.expr.ts constant.numeric.decimal.ts
                ^
                source.ts punctuation.terminator.statement.ts
                 ^
@@ -76,11 +76,11 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                 ^
-                source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                  ^
-                 source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.block.ts meta.var.expr.ts
                   ^
-                  source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                  source.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                    ^
                    source.ts meta.block.ts punctuation.terminator.statement.ts
                     ^

--- a/tests/baselines/Issue28.baseline.txt
+++ b/tests/baselines/Issue28.baseline.txt
@@ -37,11 +37,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
             ^
             source.ts punctuation.terminator.statement.ts
 >var y = 0x123;
@@ -54,11 +54,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.hex.ts
+         source.ts meta.var.expr.ts constant.numeric.hex.ts
               ^
               source.ts punctuation.terminator.statement.ts
 >var z = 0b10101;
@@ -71,11 +71,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.binary.ts
+         source.ts meta.var.expr.ts constant.numeric.binary.ts
                 ^
                 source.ts punctuation.terminator.statement.ts
 >var z = 0B00000;
@@ -88,11 +88,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.binary.ts
+         source.ts meta.var.expr.ts constant.numeric.binary.ts
                 ^
                 source.ts punctuation.terminator.statement.ts
 >var j = 0o474774;
@@ -105,11 +105,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.octal.ts
+         source.ts meta.var.expr.ts constant.numeric.octal.ts
                  ^
                  source.ts punctuation.terminator.statement.ts
 >var w = 0O767;
@@ -122,11 +122,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.octal.ts
+         source.ts meta.var.expr.ts constant.numeric.octal.ts
               ^
               source.ts punctuation.terminator.statement.ts
 >

--- a/tests/baselines/Issue28.txt
+++ b/tests/baselines/Issue28.txt
@@ -19,22 +19,22 @@ Grammar: TypeScript.tmLanguage
 >
 >var x = 123;
          ^^^
-         [4, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+         [4, 9]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 >var y = 0x123;
          ^^^^^
-         [5, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.hex.ts 
+         [5, 9]: source.ts meta.var.expr.ts constant.numeric.hex.ts 
 >var z = 0b10101;
          ^^^^^^^
-         [6, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.binary.ts 
+         [6, 9]: source.ts meta.var.expr.ts constant.numeric.binary.ts 
 >var z = 0B00000;
          ^^^^^^^
-         [7, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.binary.ts 
+         [7, 9]: source.ts meta.var.expr.ts constant.numeric.binary.ts 
 >var j = 0o474774;
          ^^^^^^^^
-         [8, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.octal.ts 
+         [8, 9]: source.ts meta.var.expr.ts constant.numeric.octal.ts 
 >var w = 0O767;
          ^^^^^
-         [9, 9]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.octal.ts 
+         [9, 9]: source.ts meta.var.expr.ts constant.numeric.octal.ts 
 >
  ^
  [10, 1]: source.ts 

--- a/tests/baselines/Issue280.baseline.txt
+++ b/tests/baselines/Issue280.baseline.txt
@@ -75,96 +75,96 @@ Grammar: TypeScriptReact.tmLanguage
                    ^
                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
                     ^
-                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
                      ^
-                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx
                       ^^^^
-                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx variable.language.this.tsx
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx variable.language.this.tsx
                           ^
-                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx punctuation.accessor.tsx
+                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx punctuation.accessor.tsx
                            ^^^^^
-                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx variable.other.object.property.tsx
+                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx variable.other.object.property.tsx
                                 ^
-                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx punctuation.accessor.tsx
+                                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx punctuation.accessor.tsx
                                  ^^^^^^^^^
-                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx variable.other.object.property.tsx
+                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx variable.other.object.property.tsx
                                           ^
-                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx punctuation.accessor.tsx
+                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx punctuation.accessor.tsx
                                            ^^^
-                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx entity.name.function.tsx
+                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx entity.name.function.tsx
                                               ^
-                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.brace.round.tsx
                                                ^^^^^^^^
-                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx variable.parameter.tsx
+                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx variable.parameter.tsx
                                                        ^
-                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx
+                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx
                                                         ^^
-                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx storage.type.function.arrow.tsx
+                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx storage.type.function.arrow.tsx
                                                           ^
-                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx
+                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx
                                                            ^
-                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
+                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
 >     return forecast.dateFormatted +
  ^^^^^
- source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
       ^^^^^^
-      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.control.flow.tsx
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx keyword.control.flow.tsx
             ^
-            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+            source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
              ^^^^^^^^
-             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
                      ^
-                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
                       ^^^^^^^^^^^^^
-                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
                                    ^
-                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+                                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
                                     ^
-                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
 >        forecast.temperatureC +
  ^^^^^^^^
- source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
          ^^^^^^^^
-         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
                  ^
-                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
                   ^^^^^^^^^^^^
-                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
                               ^
-                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
                                ^
-                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
 >        forecast.temperatureF +
  ^^^^^^^^
- source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
          ^^^^^^^^
-         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
                  ^
-                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
                   ^^^^^^^^^^^^
-                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
                               ^
-                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
                                ^
-                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
+                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx keyword.operator.arithmetic.tsx
 >        forecast.summar;
  ^^^^^^^^
- source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
          ^^^^^^^^
-         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.object.tsx
                  ^
-                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
+                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.accessor.tsx
                   ^^^^^^
-                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx variable.other.property.tsx
                         ^
-                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.terminator.statement.tsx
+                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.terminator.statement.tsx
 >    });
  ^^^^
- source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx
+ source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx
      ^
-     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
       ^
-      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.var.expr.tsx meta.brace.round.tsx
        ^
        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx punctuation.terminator.statement.tsx
 >    return <table className="table">

--- a/tests/baselines/Issue285.baseline.txt
+++ b/tests/baselines/Issue285.baseline.txt
@@ -20,57 +20,57 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
               ^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts
 >            links: {
  ^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
              ^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                  source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                   source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts punctuation.definition.block.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts punctuation.definition.block.ts
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts
 >                new: "sample"
  ^^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts
                  ^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                        ^^^^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts
+                       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.end.ts
                               ^^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
+                              source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
 >            },
  ^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts meta.object.member.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts punctuation.definition.block.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.ts punctuation.definition.block.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                ^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+               source.ts meta.var.expr.ts meta.object-literal.ts
 >        };
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
           ^
           source.ts punctuation.terminator.statement.ts
            ^^

--- a/tests/baselines/Issue288.baseline.txt
+++ b/tests/baselines/Issue288.baseline.txt
@@ -67,20 +67,20 @@ Grammar: TypeScript.tmLanguage
                 ^
                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                 source.ts meta.var.expr.ts keyword.operator.assignment.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                  source.ts meta.var.expr.ts
                    ^^^^^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts storage.type.function.ts
+                   source.ts meta.var.expr.ts meta.function.ts storage.type.function.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                           source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                            source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                             source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
 >}
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
 >
  ^
  source.ts
@@ -118,20 +118,20 @@ Grammar: TypeScript.tmLanguage
                         ^
                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                         source.ts meta.var.expr.ts keyword.operator.assignment.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                          source.ts meta.var.expr.ts
                            ^^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts storage.type.function.ts
+                           source.ts meta.var.expr.ts meta.function.ts storage.type.function.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                                   source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                    source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                                     source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
 >}
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
 >
  ^
  source.ts
@@ -143,9 +143,9 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^^^^^^^
      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                 source.ts meta.var.expr.ts keyword.operator.assignment.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                  source.ts meta.var.expr.ts constant.numeric.decimal.ts
                    ^
                    source.ts punctuation.terminator.statement.ts
 >functionName=1;
@@ -172,9 +172,9 @@ Grammar: TypeScript.tmLanguage
             ^^^^^^^^^^^^^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                         source.ts meta.var.expr.ts keyword.operator.assignment.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                          source.ts meta.var.expr.ts constant.numeric.decimal.ts
                            ^
                            source.ts punctuation.terminator.statement.ts
 >
@@ -188,13 +188,13 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^^^^^
      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                  ^^^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                 source.ts meta.var.expr.ts string.quoted.double.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                      source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                        ^
                        source.ts punctuation.terminator.statement.ts
 >exportName2="hello";
@@ -221,9 +221,9 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^^^^^
      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts constant.numeric.decimal.ts
                  ^
                  source.ts punctuation.terminator.statement.ts
 >returnName+=1;

--- a/tests/baselines/Issue288.txt
+++ b/tests/baselines/Issue288.txt
@@ -37,7 +37,7 @@ Grammar: TypeScript.tmLanguage
 >}
 >var AnotherName = function(){
                            ^
-                           [6, 27]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
+                           [6, 27]: source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
 >}
 >
 >export function eName(){
@@ -46,7 +46,7 @@ Grammar: TypeScript.tmLanguage
 >}
 >export var eAnotherName = function(){
                                    ^
-                                   [11, 35]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
+                                   [11, 35]: source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts 
 >}
 >
 >var functionName=1;

--- a/tests/baselines/Issue292.baseline.txt
+++ b/tests/baselines/Issue292.baseline.txt
@@ -32,43 +32,43 @@ Grammar: TypeScript.tmLanguage
                                  ^
                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                  source.ts meta.var.expr.ts keyword.operator.assignment.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                   source.ts meta.var.expr.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                    source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                                      ^^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                     source.ts meta.var.expr.ts meta.object-literal.ts
 >        filesToOpen,
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts
 >        filesToCreate,
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                        ^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                       source.ts meta.var.expr.ts meta.object-literal.ts
 >        filesToDiff
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                     ^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
 >    };
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
       ^
       source.ts punctuation.terminator.statement.ts
        ^^
@@ -85,58 +85,58 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+              source.ts meta.var.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+               source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                source.ts meta.var.expr.ts meta.object-literal.ts
 >        filesToOpen: filesToOpen,
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                       ^^^^^^^^^^^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                 source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                                   ^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                  source.ts meta.var.expr.ts meta.object-literal.ts
 >        filesToCreate: filesToCreate,
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                         ^^^^^^^^^^^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+                        source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                     source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                                       ^^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                      source.ts meta.var.expr.ts meta.object-literal.ts
 >        filesToDiff: filesToDiff
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                       ^^^^^^^^^^^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                                  ^^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
 >    }
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts

--- a/tests/baselines/Issue294.baseline.txt
+++ b/tests/baselines/Issue294.baseline.txt
@@ -56,11 +56,11 @@ Grammar: TypeScript.tmLanguage
                    ^
                    source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                     ^
-                    source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                    source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                      ^
-                     source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                     source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts meta.var.expr.ts
                       ^
-                      source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                      source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts meta.var.expr.ts constant.numeric.decimal.ts
                        ^
                        source.ts switch-statement.expr.ts switch-block.expr.ts meta.block.ts punctuation.terminator.statement.ts
                         ^^

--- a/tests/baselines/Issue3.baseline.txt
+++ b/tests/baselines/Issue3.baseline.txt
@@ -15,20 +15,20 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+             source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                ^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts comment.block.ts punctuation.definition.comment.ts
+               source.ts meta.var.expr.ts comment.block.ts punctuation.definition.comment.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts
+                 source.ts meta.var.expr.ts string.regex.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts punctuation.definition.string.begin.ts
+                  source.ts meta.var.expr.ts string.regex.ts punctuation.definition.string.begin.ts
                    ^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts
+                   source.ts meta.var.expr.ts string.regex.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts punctuation.definition.string.end.ts
+                      source.ts meta.var.expr.ts string.regex.ts punctuation.definition.string.end.ts
                        ^
                        source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue304.baseline.txt
+++ b/tests/baselines/Issue304.baseline.txt
@@ -27,204 +27,204 @@ Grammar: TypeScript.tmLanguage
                          ^
                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                          source.ts meta.var.expr.ts keyword.operator.assignment.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                           source.ts meta.var.expr.ts
                             ^^^^^^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                            source.ts meta.var.expr.ts entity.name.function.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                   source.ts meta.var.expr.ts meta.brace.round.ts
                                     ^^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                    source.ts meta.var.expr.ts
 >    (state: Immutable<AppState>): Object => ( {
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+ source.ts meta.var.expr.ts meta.arrow.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+     source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
       ^^^^^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+      source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+           source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+            source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
              ^^^^^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+             source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                      source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                        ^^^^^^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts entity.name.type.ts
+                       source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts entity.name.type.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                               source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts keyword.operator.type.annotation.ts
+                                 source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts keyword.operator.type.annotation.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                                  source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts
                                    ^^^^^^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts entity.name.type.ts
+                                   source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts entity.name.type.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                                         source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts
                                           ^^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                          source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                            source.ts meta.var.expr.ts meta.arrow.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                             source.ts meta.var.expr.ts meta.brace.round.ts
                                               ^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                              source.ts meta.var.expr.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                               source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                                                 ^^
-                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                                source.ts meta.var.expr.ts meta.object-literal.ts
 >        edditorState: (state.editors[state.activeTab]),
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.brace.round.ts
+                       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.brace.round.ts
                         ^^^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
+                        source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
+                             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
                               ^^^^^^^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
+                              source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts meta.brace.square.ts
+                                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts meta.brace.square.ts
                                       ^^^^^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts variable.other.object.ts
+                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts variable.other.object.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts punctuation.accessor.ts
+                                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts punctuation.accessor.ts
                                             ^^^^^^^^^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts variable.other.property.ts
+                                            source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts variable.other.property.ts
                                                      ^
-                                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts meta.brace.square.ts
+                                                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts meta.brace.square.ts
                                                       ^
-                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.brace.round.ts
+                                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.brace.round.ts
                                                        ^
-                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                                       source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                                                         ^^
-                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                                        source.ts meta.var.expr.ts meta.object-literal.ts
 >        macroSettingsOpen: state.macroSettingsOpen,
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                             ^^^^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
+                            source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
+                                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
                                   ^^^^^^^^^^^^^^^^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
+                                  source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
                                                    ^
-                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                                   source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                                                     ^^
-                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                                    source.ts meta.var.expr.ts meta.object-literal.ts
 >    }),
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
       ^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+      source.ts meta.var.expr.ts meta.brace.round.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.separator.comma.ts
+       source.ts meta.var.expr.ts punctuation.separator.comma.ts
         ^^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
 >    (dispatch: Dispatch): Object => ({
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+ source.ts meta.var.expr.ts meta.arrow.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+     source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
       ^^^^^^^^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+      source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+              source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+               source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
                 ^^^^^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                        source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts keyword.operator.type.annotation.ts
+                         source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts keyword.operator.type.annotation.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                          source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts
                            ^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts entity.name.type.ts
+                           source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts entity.name.type.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                                 source.ts meta.var.expr.ts meta.arrow.ts meta.return.type.arrow.ts
                                   ^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                  source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                    source.ts meta.var.expr.ts meta.arrow.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                     source.ts meta.var.expr.ts meta.brace.round.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                      source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                                        ^^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                       source.ts meta.var.expr.ts meta.object-literal.ts
 >        onchange(next: EditorSDtate): void { dispatch(actions) }
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
          ^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                   ^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                  source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                       source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
                         ^^^^^^^^^^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                        source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                    source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts keyword.operator.type.annotation.ts
+                                     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts keyword.operator.type.annotation.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts
+                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts
                                        ^^^^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts support.type.primitive.ts
+                                       source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts support.type.primitive.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts
+                                           source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                                            source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                                             source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
                                               ^^^^^^^^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts entity.name.function.ts
+                                              source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts entity.name.function.ts
                                                       ^
-                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.brace.round.ts
+                                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.brace.round.ts
                                                        ^^^^^^^
-                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts variable.other.readwrite.ts
+                                                       source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts variable.other.readwrite.ts
                                                               ^
-                                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.brace.round.ts
+                                                              source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.brace.round.ts
                                                                ^
-                                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                                                               source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
                                                                 ^
-                                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                                                                source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
                                                                  ^^
-                                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                                                 source.ts meta.var.expr.ts meta.object-literal.ts
 >    })
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
       ^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+      source.ts meta.var.expr.ts meta.brace.round.ts
        ^^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+       source.ts meta.var.expr.ts
 >)
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+ source.ts meta.var.expr.ts meta.brace.round.ts

--- a/tests/baselines/Issue304.baseline.txt
+++ b/tests/baselines/Issue304.baseline.txt
@@ -1,0 +1,230 @@
+original file
+-----------------------------------
+export const EditorPanel = connect(
+    (state: Immutable<AppState>): Object => ( {
+        edditorState: (state.editors[state.activeTab]),
+        macroSettingsOpen: state.macroSettingsOpen,
+    }),
+    (dispatch: Dispatch): Object => ({
+        onchange(next: EditorSDtate): void { dispatch(actions) }
+    })
+)
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>export const EditorPanel = connect(
+ ^^^^^^
+ source.ts meta.var.expr.ts keyword.control.export.ts
+       ^
+       source.ts meta.var.expr.ts
+        ^^^^^
+        source.ts meta.var.expr.ts storage.type.ts
+             ^
+             source.ts meta.var.expr.ts
+              ^^^^^^^^^^^
+              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                         ^
+                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                          ^
+                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                           ^
+                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                            ^^^^^^^
+                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                                   ^
+                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                    ^^
+                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+>    (state: Immutable<AppState>): Object => ( {
+ ^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+     ^
+     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+      ^^^^^
+      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+           ^
+           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+            ^
+            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+             ^^^^^^^^^
+             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                      ^
+                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                       ^^^^^^^^
+                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts entity.name.type.ts
+                               ^
+                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                ^
+                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                 ^
+                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts keyword.operator.type.annotation.ts
+                                  ^
+                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                                   ^^^^^^
+                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts entity.name.type.ts
+                                         ^
+                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                                          ^^
+                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                            ^
+                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                             ^
+                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                              ^
+                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                               ^
+                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                                ^^
+                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+>        edditorState: (state.editors[state.activeTab]),
+ ^^^^^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+         ^^^^^^^^^^^^
+         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                     ^
+                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                      ^
+                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                       ^
+                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.brace.round.ts
+                        ^^^^^
+                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
+                             ^
+                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
+                              ^^^^^^^
+                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
+                                     ^
+                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts meta.brace.square.ts
+                                      ^^^^^
+                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts variable.other.object.ts
+                                           ^
+                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts punctuation.accessor.ts
+                                            ^^^^^^^^^
+                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts variable.other.property.ts
+                                                     ^
+                                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.array.literal.ts meta.brace.square.ts
+                                                      ^
+                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.brace.round.ts
+                                                       ^
+                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                                        ^^
+                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+>        macroSettingsOpen: state.macroSettingsOpen,
+ ^^^^^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+         ^^^^^^^^^^^^^^^^^
+         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                          ^
+                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                           ^
+                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                            ^^^^^
+                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
+                                 ^
+                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
+                                  ^^^^^^^^^^^^^^^^^
+                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
+                                                   ^
+                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                                    ^^
+                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+>    }),
+ ^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+     ^
+     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+      ^
+      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+       ^
+       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.separator.comma.ts
+        ^^
+        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+>    (dispatch: Dispatch): Object => ({
+ ^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+     ^
+     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+      ^^^^^^^^
+      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts variable.parameter.ts
+              ^
+              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+               ^
+               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts
+                ^^^^^^^^
+                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                        ^
+                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                         ^
+                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts keyword.operator.type.annotation.ts
+                          ^
+                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                           ^^^^^^
+                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts entity.name.type.ts
+                                 ^
+                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.return.type.arrow.ts
+                                  ^^
+                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                    ^
+                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                     ^
+                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                      ^
+                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                       ^^
+                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+>        onchange(next: EditorSDtate): void { dispatch(actions) }
+ ^^^^^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+         ^^^^^^^^
+         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
+                 ^
+                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                  ^^^^
+                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                      ^
+                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                       ^
+                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                        ^^^^^^^^^^^^
+                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                                    ^
+                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                     ^
+                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts keyword.operator.type.annotation.ts
+                                      ^
+                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts
+                                       ^^^^
+                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts support.type.primitive.ts
+                                           ^
+                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.return.type.ts
+                                            ^
+                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                                             ^
+                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                                              ^^^^^^^^
+                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts entity.name.function.ts
+                                                      ^
+                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.brace.round.ts
+                                                       ^^^^^^^
+                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts variable.other.readwrite.ts
+                                                              ^
+                                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.brace.round.ts
+                                                               ^
+                                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                                                                ^
+                                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                                                                 ^^
+                                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+>    })
+ ^^^^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+     ^
+     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+      ^
+      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+       ^^
+       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+>)
+ ^
+ source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts

--- a/tests/baselines/Issue305.baseline.txt
+++ b/tests/baselines/Issue305.baseline.txt
@@ -35,7 +35,7 @@ Grammar: TypeScript.tmLanguage
                ^^^^^^^^
                source.ts meta.class.ts storage.modifier.ts
                        ^
-                       source.ts meta.class.ts meta.field.declaration.ts
+                       source.ts meta.class.ts
                         ^^^^^
                         source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                              ^

--- a/tests/baselines/Issue305.baseline.txt
+++ b/tests/baselines/Issue305.baseline.txt
@@ -1,0 +1,118 @@
+original file
+-----------------------------------
+abstract class Base {
+    protected abstract topic: string
+    constructor(protected wire: Transport, protected token?: string, readonly bar?: boolean) { }
+}
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>abstract class Base {
+ ^^^^^^^^
+ source.ts meta.class.ts storage.modifier.ts
+         ^
+         source.ts meta.class.ts
+          ^^^^^
+          source.ts meta.class.ts storage.type.class.ts
+               ^
+               source.ts meta.class.ts
+                ^^^^
+                source.ts meta.class.ts entity.name.class.ts
+                    ^
+                    source.ts meta.class.ts
+                     ^
+                     source.ts meta.class.ts punctuation.definition.block.ts
+                      ^^
+                      source.ts meta.class.ts
+>    protected abstract topic: string
+ ^^^^
+ source.ts meta.class.ts
+     ^^^^^^^^^
+     source.ts meta.class.ts storage.modifier.ts
+              ^
+              source.ts meta.class.ts
+               ^^^^^^^^
+               source.ts meta.class.ts storage.modifier.ts
+                       ^
+                       source.ts meta.class.ts meta.field.declaration.ts
+                        ^^^^^
+                        source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
+                             ^
+                             source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                              ^
+                              source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts
+                               ^^^^^^
+                               source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts support.type.primitive.ts
+                                     ^
+                                     source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts
+>    constructor(protected wire: Transport, protected token?: string, readonly bar?: boolean) { }
+ ^^^^
+ source.ts meta.class.ts
+     ^^^^^^^^^^^
+     source.ts meta.class.ts meta.method.declaration.ts storage.type.ts
+                ^
+                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                 ^^^^^^^^^
+                 source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts storage.modifier.ts
+                          ^
+                          source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts
+                           ^^^^
+                           source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                               ^
+                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                ^
+                                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                                 ^^^^^^^^^
+                                 source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                                          ^
+                                          source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.separator.parameter.ts
+                                           ^
+                                           source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts
+                                            ^^^^^^^^^
+                                            source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts storage.modifier.ts
+                                                     ^
+                                                     source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts
+                                                      ^^^^^
+                                                      source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                                                           ^
+                                                           source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts keyword.operator.optional.ts
+                                                            ^
+                                                            source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                                             ^
+                                                             source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                                                              ^^^^^^
+                                                              source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                                                                    ^
+                                                                    source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.separator.parameter.ts
+                                                                     ^
+                                                                     source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts
+                                                                      ^^^^^^^^
+                                                                      source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts storage.modifier.ts
+                                                                              ^
+                                                                              source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts
+                                                                               ^^^
+                                                                               source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts variable.parameter.ts
+                                                                                  ^
+                                                                                  source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts keyword.operator.optional.ts
+                                                                                   ^
+                                                                                   source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                                                                                    ^
+                                                                                    source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts
+                                                                                     ^^^^^^^
+                                                                                     source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts meta.type.annotation.ts support.type.primitive.ts
+                                                                                            ^
+                                                                                            source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                                                                             ^
+                                                                                             source.ts meta.class.ts meta.method.declaration.ts
+                                                                                              ^
+                                                                                              source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                                                                                               ^
+                                                                                               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+                                                                                                ^
+                                                                                                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+                                                                                                 ^^
+                                                                                                 source.ts meta.class.ts
+>}
+ ^
+ source.ts meta.class.ts punctuation.definition.block.ts

--- a/tests/baselines/Issue307.baseline.txt
+++ b/tests/baselines/Issue307.baseline.txt
@@ -1,0 +1,152 @@
+original file
+-----------------------------------
+class Test {
+  method() {
+    const obj = { a: 'hello' };
+    const {
+      a
+    } = obj;
+    const x = 'world';
+  }
+}
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>class Test {
+ ^^^^^
+ source.ts meta.class.ts storage.type.class.ts
+      ^
+      source.ts meta.class.ts
+       ^^^^
+       source.ts meta.class.ts entity.name.class.ts
+           ^
+           source.ts meta.class.ts
+            ^
+            source.ts meta.class.ts punctuation.definition.block.ts
+             ^^
+             source.ts meta.class.ts
+>  method() {
+ ^^
+ source.ts meta.class.ts
+   ^^^^^^
+   source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
+         ^
+         source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+          ^
+          source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+           ^
+           source.ts meta.class.ts meta.method.declaration.ts
+            ^
+            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+             ^^
+             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+>    const obj = { a: 'hello' };
+ ^^^^
+ source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+     ^^^^^
+     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts storage.type.ts
+          ^
+          source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
+           ^^^
+           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+              ^
+              source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               ^
+               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
+                ^
+                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
+                 ^
+                 source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                  ^
+                  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts
+                   ^
+                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                    ^
+                    source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                     ^
+                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
+                      ^
+                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                       ^^^^^
+                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.single.ts
+                            ^
+                            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                             ^
+                             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
+                              ^
+                              source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                               ^
+                               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
+                                ^^
+                                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+>    const {
+ ^^^^
+ source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+     ^^^^^
+     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts storage.type.ts
+          ^
+          source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+           ^
+           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.definition.binding-pattern.object.ts
+            ^^
+            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+>      a
+ ^^^^^^
+ source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+       ^
+       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.other.readwrite.ts
+        ^^
+        source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+>    } = obj;
+ ^^^^
+ source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+     ^
+     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.definition.binding-pattern.object.ts
+      ^
+      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+       ^
+       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
+        ^
+        source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
+         ^^^
+         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts
+            ^
+            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
+             ^^
+             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+>    const x = 'world';
+ ^^^^
+ source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+     ^^^^^
+     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts storage.type.ts
+          ^
+          source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
+           ^
+           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+            ^
+            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             ^
+             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
+              ^
+              source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
+               ^
+               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                ^^^^^
+                source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts string.quoted.single.ts
+                     ^
+                     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                      ^
+                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
+                       ^^
+                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+>  }
+ ^^
+ source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
+   ^
+   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+    ^^
+    source.ts meta.class.ts
+>}
+ ^
+ source.ts meta.class.ts punctuation.definition.block.ts

--- a/tests/baselines/Issue32.baseline.txt
+++ b/tests/baselines/Issue32.baseline.txt
@@ -48,7 +48,7 @@ Grammar: TypeScript.tmLanguage
                        source.ts meta.class.ts punctuation.definition.block.ts
 >	currentData: Data;
  ^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
   ^^^^^^^^^^^
   source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^
@@ -106,7 +106,7 @@ Grammar: TypeScript.tmLanguage
                                         source.ts meta.class.ts punctuation.definition.block.ts
 >	currentData: Data;
  ^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
   ^^^^^^^^^^^
   source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^

--- a/tests/baselines/Issue36.baseline.txt
+++ b/tests/baselines/Issue36.baseline.txt
@@ -19,62 +19,62 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
           ^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+          source.ts meta.var.expr.ts meta.object-literal.ts
 >    hello() {
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
      ^^^^^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts entity.name.function.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+          source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+           source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.end.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
               ^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
 >        let hello = "world";
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
          ^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts storage.type.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts storage.type.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
              ^^^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                  source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                   source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                       ^^^^^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
+                            source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.terminator.statement.ts
                              ^^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+                             source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
 >    }
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.method.declaration.ts meta.block.ts punctuation.definition.block.ts
       ^^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+      source.ts meta.var.expr.ts meta.object-literal.ts
 >};
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
   ^
   source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue37.baseline.txt
+++ b/tests/baselines/Issue37.baseline.txt
@@ -280,19 +280,19 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
         ^
-        source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+        source.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+         source.ts meta.block.ts meta.var.expr.ts
           ^
-          source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+          source.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts
            ^
-           source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.block.ts meta.var.expr.ts
             ^
-            source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+            source.ts meta.block.ts meta.var.expr.ts keyword.operator.arithmetic.ts
              ^
-             source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.block.ts meta.var.expr.ts
               ^
-              source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+              source.ts meta.block.ts meta.var.expr.ts variable.other.readwrite.ts
                ^
                source.ts meta.block.ts punctuation.terminator.statement.ts
 >
@@ -474,11 +474,11 @@ Grammar: TypeScript.tmLanguage
                 ^
                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                 source.ts meta.var.expr.ts keyword.operator.assignment.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                  source.ts meta.var.expr.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.other.ts
+                   source.ts meta.var.expr.ts constant.other.ts
                     ^
                     source.ts punctuation.terminator.statement.ts
 >
@@ -494,27 +494,27 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts
+             source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts
+                source.ts meta.var.expr.ts new.expr.ts
                  ^^^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts entity.name.type.ts
+                 source.ts meta.var.expr.ts new.expr.ts entity.name.type.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                      source.ts meta.var.expr.ts meta.brace.round.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                       source.ts meta.var.expr.ts constant.numeric.decimal.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.separator.comma.ts
+                        source.ts meta.var.expr.ts punctuation.separator.comma.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                          source.ts meta.var.expr.ts constant.numeric.decimal.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                           source.ts meta.var.expr.ts meta.brace.round.ts
                             ^
                             source.ts punctuation.terminator.statement.ts
 >delete (adder)
@@ -541,21 +541,21 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.typeof.ts
+         source.ts meta.var.expr.ts keyword.operator.typeof.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+               source.ts meta.var.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                   ^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                  source.ts meta.var.expr.ts variable.other.readwrite.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                     source.ts meta.var.expr.ts
 >interface I {}
  ^^^^^^^^^
  source.ts meta.class.ts storage.type.interface.ts
@@ -585,13 +585,13 @@ Grammar: TypeScript.tmLanguage
          ^
          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+          source.ts meta.var.expr.ts keyword.operator.assignment.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.var.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
 >
  ^
  source.ts

--- a/tests/baselines/Issue37.baseline.txt
+++ b/tests/baselines/Issue37.baseline.txt
@@ -231,7 +231,7 @@ Grammar: TypeScript.tmLanguage
   ^^^^^^^
   source.ts meta.class.ts storage.modifier.ts
          ^
-         source.ts meta.class.ts meta.field.declaration.ts
+         source.ts meta.class.ts
           ^^^^^
           source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^
@@ -632,7 +632,7 @@ Grammar: TypeScript.tmLanguage
          ^^^^^^
          source.ts meta.block.ts meta.class.ts storage.modifier.ts
                ^
-               source.ts meta.block.ts meta.class.ts meta.field.declaration.ts
+               source.ts meta.block.ts meta.class.ts
                 ^^^^^^
                 source.ts meta.block.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                       ^

--- a/tests/baselines/Issue37.txt
+++ b/tests/baselines/Issue37.txt
@@ -128,7 +128,7 @@ Grammar: TypeScript.tmLanguage
   ^^^
   [21, 2]: source.ts meta.block.ts meta.var.expr.ts storage.type.ts 
             ^
-            [21, 12]: source.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts 
+            [21, 12]: source.ts meta.block.ts meta.var.expr.ts keyword.operator.arithmetic.ts 
 >
 >	switch (someNum) {
   ^^^^^^
@@ -166,7 +166,7 @@ Grammar: TypeScript.tmLanguage
 >
 >var adder = new Adder(3, 4);
              ^^^
-             [43, 13]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts new.expr.ts keyword.operator.new.ts 
+             [43, 13]: source.ts meta.var.expr.ts new.expr.ts keyword.operator.new.ts 
 >delete (adder)
  ^^^^^^
  [44, 1]: source.ts keyword.operator.delete.ts 

--- a/tests/baselines/Issue43.baseline.txt
+++ b/tests/baselines/Issue43.baseline.txt
@@ -16,17 +16,17 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+             source.ts meta.var.expr.ts entity.name.function.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+              source.ts meta.var.expr.ts meta.brace.round.ts
                ^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.language.this.ts
+               source.ts meta.var.expr.ts variable.language.this.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                   source.ts meta.var.expr.ts meta.brace.round.ts
                     ^
                     source.ts punctuation.terminator.statement.ts
                      ^^

--- a/tests/baselines/Issue44.baseline.txt
+++ b/tests/baselines/Issue44.baseline.txt
@@ -30,7 +30,7 @@ Grammar: TypeScript.tmLanguage
                          source.ts meta.class.ts punctuation.definition.block.ts
 >  testvar: string;
  ^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
    ^^^^^^^
    source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
           ^

--- a/tests/baselines/Issue5.baseline.txt
+++ b/tests/baselines/Issue5.baseline.txt
@@ -49,15 +49,15 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                source.ts meta.var.expr.ts keyword.operator.assignment.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.var.expr.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                    ^^^^^^^^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                   source.ts meta.var.expr.ts string.quoted.double.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                              source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >
  ^
  source.ts
@@ -74,30 +74,30 @@ Grammar: TypeScript.tmLanguage
                       ^
                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                       source.ts meta.var.expr.ts keyword.operator.assignment.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                        source.ts meta.var.expr.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                         source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                           ^^^^^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                          source.ts meta.var.expr.ts string.quoted.double.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                               source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >this link to github is https://github.com/\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                                           source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >hello\
  ^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
       ^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+      source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >World"
  ^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
       ^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+      source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >
  ^
  source.ts
@@ -109,34 +109,34 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^^^^^^^^^^^^
      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                      source.ts meta.var.expr.ts keyword.operator.assignment.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                       source.ts meta.var.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                        source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                          ^^^^^^^^^^^^^^^^^^^^^^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                         source.ts meta.var.expr.ts string.quoted.single.ts
                                                 ^
-                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                                                source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >hello world \\\\\
  ^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
              ^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+             source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                ^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+               source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                 source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >let this be   ^\
  ^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >a good test   ^'
  ^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
 >
  ^
  source.ts
@@ -150,65 +150,65 @@ Grammar: TypeScript.tmLanguage
                        ^
                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                        source.ts meta.var.expr.ts keyword.operator.assignment.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                          source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                            ^^^^^^^^^^^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                           source.ts meta.var.expr.ts string.quoted.double.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                                            source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >    name: string.double.ts\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                           source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >    begin: \'\"\'\
  ^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
             ^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+            source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
               ^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+              source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >    end: \'\"|(?:[^\r\n\\]$)'\
  ^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
           ^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+          source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
             ^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+            source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
               ^^^^^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+              source.ts meta.var.expr.ts string.quoted.double.ts
                     ^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                    source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
                       ^^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                      source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
                         ^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                        source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
                           ^^^^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                          source.ts meta.var.expr.ts string.quoted.double.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                              source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >    patterns:\
  ^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+              source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >    - include: '#string-character-escape'\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts
+                                          source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts
 >    "
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+ source.ts meta.var.expr.ts string.quoted.double.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+     source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >
  ^
  source.ts
@@ -222,87 +222,87 @@ Grammar: TypeScript.tmLanguage
                        ^
                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                        source.ts meta.var.expr.ts keyword.operator.assignment.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                          source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                            ^^^^^^^^^^^^^^^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                           source.ts meta.var.expr.ts string.quoted.single.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                                          source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >    name: string.single.ts\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                           source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >    begin: \"\'\"\
  ^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
             ^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+            source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
               ^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+              source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                  source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >    end: \'|(?:[^\r\n\\]$)\
  ^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
           ^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+          source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
             ^^^^^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+            source.ts meta.var.expr.ts string.quoted.single.ts
                   ^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                  source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                     ^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                    source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                       ^^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                      source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                         ^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                        source.ts meta.var.expr.ts string.quoted.single.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                           source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >    endCaptures:\
  ^^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                 source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >      '0': {name: string-character-escape }\
  ^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+       source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+        source.ts meta.var.expr.ts constant.numeric.decimal.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+         source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+          source.ts meta.var.expr.ts string.quoted.single.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                                            source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >    patterns:\
  ^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+              source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >    - include: \'#string-character-escape\'\
  ^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
                 ^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                   ^^^^^^^^^^^^^^^^^^^^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+                  source.ts meta.var.expr.ts string.quoted.single.ts
                                           ^^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                                          source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts
+                                            source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts
 >    '
  ^^^^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts
+ source.ts meta.var.expr.ts string.quoted.single.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
+     source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts
 >
  ^
  source.ts
@@ -316,15 +316,15 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                source.ts meta.var.expr.ts keyword.operator.assignment.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.var.expr.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                    ^^^^^^^^^^^^^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                   source.ts meta.var.expr.ts string.quoted.double.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                   source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >
  ^
  source.ts

--- a/tests/baselines/Issue5.txt
+++ b/tests/baselines/Issue5.txt
@@ -41,9 +41,9 @@ Grammar: TypeScript.tmLanguage
 -----------------------------------
 >let new_string = "New Changes"
                   ^
-                  [1, 18]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts 
+                  [1, 18]: source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts 
                    ^^^^^^^^^^^
-                   [1, 19]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+                   [1, 19]: source.ts meta.var.expr.ts string.quoted.double.ts 
 >
  ^
  [2, 1]: source.ts 
@@ -51,110 +51,110 @@ Grammar: TypeScript.tmLanguage
 >let plain_double_text = "Hello\
 >this link to github is https://github.com/\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- [5, 23]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [5, 23]: source.ts meta.var.expr.ts string.quoted.double.ts 
 >hello\
       ^
-      [6, 6]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts 
+      [6, 6]: source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts 
 >World"
 >
 >let plain_single_text= 'Try with single bracket\
                         ^
-                        [9, 24]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
+                        [9, 24]: source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.begin.ts 
 >hello world \\\\\
              ^^
-             [10, 13]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+             [10, 13]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >let this be   ^\
 >a good test   ^'
 >
 >let double_quote_issue = "  qstring-double:\
                            ^^^^^^^^^^^^^^^^^
-                           [14, 28]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+                           [14, 28]: source.ts meta.var.expr.ts string.quoted.double.ts 
 >    name: string.double.ts\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
- [15, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [15, 5]: source.ts meta.var.expr.ts string.quoted.double.ts 
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
- [15, 11]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [15, 11]: source.ts meta.var.expr.ts string.quoted.double.ts 
                            ^
-                           [15, 27]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts 
+                           [15, 27]: source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts 
 >    begin: \'\"\'\
  ^^^^^^^^^^^
- [16, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [16, 5]: source.ts meta.var.expr.ts string.quoted.double.ts 
             ^^
-            [16, 12]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts 
+            [16, 12]: source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts 
 >    end: \'\"|(?:[^\r\n\\]$)'\
  ^^^^^^^^^
- [17, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [17, 5]: source.ts meta.var.expr.ts string.quoted.double.ts 
           ^^
-          [17, 10]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts 
+          [17, 10]: source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts 
 >    patterns:\
  ^^^^^^^^^^^^^
- [18, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [18, 5]: source.ts meta.var.expr.ts string.quoted.double.ts 
               ^
-              [18, 14]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts 
+              [18, 14]: source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts 
 >    - include: '#string-character-escape'\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- [19, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [19, 5]: source.ts meta.var.expr.ts string.quoted.double.ts 
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- [19, 16]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+ [19, 16]: source.ts meta.var.expr.ts string.quoted.double.ts 
                                           ^
-                                          [19, 42]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts constant.character.escape.ts 
+                                          [19, 42]: source.ts meta.var.expr.ts string.quoted.double.ts constant.character.escape.ts 
 >    "
      ^
-     [20, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts 
+     [20, 5]: source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts 
 >
  ^
  [21, 1]: source.ts 
 >let single_quote_issue = 'qstring-single:\
                            ^^^^^^^^^^^^^^^
-                           [22, 27]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+                           [22, 27]: source.ts meta.var.expr.ts string.quoted.single.ts 
                                           ^
-                                          [22, 42]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+                                          [22, 42]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >    name: string.single.ts\
  ^^^^^^^^^^^^^^^^^^^^^^^^^^
- [23, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+ [23, 5]: source.ts meta.var.expr.ts string.quoted.single.ts 
                            ^
-                           [23, 27]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+                           [23, 27]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >    begin: \"\'\"\
  ^^^^^^^^^^^
- [24, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+ [24, 5]: source.ts meta.var.expr.ts string.quoted.single.ts 
 >    end: \'|(?:[^\r\n\\]$)\
  ^^^^^^^^^
- [25, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+ [25, 5]: source.ts meta.var.expr.ts string.quoted.single.ts 
                            ^
-                           [25, 27]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+                           [25, 27]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >    endCaptures:\
  ^^^^^^^^^^^^^^^^
- [26, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+ [26, 5]: source.ts meta.var.expr.ts string.quoted.single.ts 
                  ^
-                 [26, 17]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+                 [26, 17]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >      '0': {name: string-character-escape }\
  ^^^^^^
- [27, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+ [27, 5]: source.ts meta.var.expr.ts string.quoted.single.ts 
                                             ^
-                                            [27, 44]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+                                            [27, 44]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >    patterns:\
  ^^^^^^^^^^^^^
- [28, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+ [28, 5]: source.ts meta.var.expr.ts string.quoted.single.ts 
               ^
-              [28, 14]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+              [28, 14]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >    - include: \'#string-character-escape\'\
  ^^^^^^^^^^^^^^^
- [29, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts 
+ [29, 5]: source.ts meta.var.expr.ts string.quoted.single.ts 
                                             ^
-                                            [29, 44]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts constant.character.escape.ts 
+                                            [29, 44]: source.ts meta.var.expr.ts string.quoted.single.ts constant.character.escape.ts 
 >    '
      ^
-     [30, 5]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts 
+     [30, 5]: source.ts meta.var.expr.ts string.quoted.single.ts punctuation.definition.string.end.ts 
 >
  ^
  [31, 1]: source.ts 
 >let new_string = "Changes End here"
                   ^
-                  [32, 18]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts 
+                  [32, 18]: source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts 
                    ^^^^^^^^^^^^^^^^
-                   [32, 19]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts 
+                   [32, 19]: source.ts meta.var.expr.ts string.quoted.double.ts 
                                    ^
-                                   [32, 35]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts 
+                                   [32, 35]: source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts 
 >
  ^
  [33, 1]: source.ts 

--- a/tests/baselines/Issue59.baseline.txt
+++ b/tests/baselines/Issue59.baseline.txt
@@ -27,7 +27,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^^^^^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                  ^
@@ -60,7 +60,7 @@ Grammar: TypeScript.tmLanguage
      ^^^^^^
      source.ts meta.class.ts storage.modifier.ts
            ^
-           source.ts meta.class.ts meta.field.declaration.ts
+           source.ts meta.class.ts
             ^
             source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
              ^

--- a/tests/baselines/Issue63.baseline.txt
+++ b/tests/baselines/Issue63.baseline.txt
@@ -302,7 +302,7 @@ Grammar: TypeScript.tmLanguage
  source.ts meta.type.declaration.ts meta.object.type.ts
 >	foo: T,
  ^
- source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.type.declaration.ts meta.object.type.ts
   ^^^
   source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
      ^
@@ -315,7 +315,7 @@ Grammar: TypeScript.tmLanguage
         source.ts meta.type.declaration.ts meta.object.type.ts punctuation.separator.comma.ts
 >	bar: number
  ^
- source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.type.declaration.ts meta.object.type.ts
   ^^^
   source.ts meta.type.declaration.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
      ^

--- a/tests/baselines/Issue66.baseline.txt
+++ b/tests/baselines/Issue66.baseline.txt
@@ -22,27 +22,27 @@ Grammar: TypeScriptReact.tmLanguage
         ^
         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+         source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
           ^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+          source.tsx meta.var.expr.tsx
            ^^^
-           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx new.expr.tsx keyword.operator.new.tsx
+           source.tsx meta.var.expr.tsx new.expr.tsx keyword.operator.new.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx new.expr.tsx
+              source.tsx meta.var.expr.tsx new.expr.tsx
                ^^^^^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx new.expr.tsx entity.name.type.tsx
+               source.tsx meta.var.expr.tsx new.expr.tsx entity.name.type.tsx
                     ^
-                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx new.expr.tsx meta.type.parameters.tsx punctuation.definition.typeparameters.begin.tsx
+                    source.tsx meta.var.expr.tsx new.expr.tsx meta.type.parameters.tsx punctuation.definition.typeparameters.begin.tsx
                      ^
-                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx new.expr.tsx meta.type.parameters.tsx meta.object.type.tsx punctuation.definition.block.tsx
+                     source.tsx meta.var.expr.tsx new.expr.tsx meta.type.parameters.tsx meta.object.type.tsx punctuation.definition.block.tsx
                       ^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx new.expr.tsx meta.type.parameters.tsx meta.object.type.tsx punctuation.definition.block.tsx
+                      source.tsx meta.var.expr.tsx new.expr.tsx meta.type.parameters.tsx meta.object.type.tsx punctuation.definition.block.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx new.expr.tsx meta.type.parameters.tsx punctuation.definition.typeparameters.end.tsx
+                       source.tsx meta.var.expr.tsx new.expr.tsx meta.type.parameters.tsx punctuation.definition.typeparameters.end.tsx
                         ^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+                        source.tsx meta.var.expr.tsx meta.brace.round.tsx
                          ^
-                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+                         source.tsx meta.var.expr.tsx meta.brace.round.tsx
                           ^
                           source.tsx punctuation.terminator.statement.tsx
                            ^^

--- a/tests/baselines/Issue77.baseline.txt
+++ b/tests/baselines/Issue77.baseline.txt
@@ -43,27 +43,27 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts cast.expr.ts meta.object.type.ts punctuation.definition.block.ts
          ^
-         source.ts cast.expr.ts meta.object.type.ts meta.indexer.declaration.ts meta.brace.square.ts
+         source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.array.literal.ts meta.brace.square.ts
           ^^^
-          source.ts cast.expr.ts meta.object.type.ts meta.indexer.declaration.ts meta.indexer.parameter.ts variable.parameter.ts
+          source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.array.literal.ts variable.other.readwrite.ts
              ^
-             source.ts cast.expr.ts meta.object.type.ts meta.indexer.declaration.ts meta.brace.square.ts
+             source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.array.literal.ts meta.brace.square.ts
               ^
-              source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+              source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                ^
-               source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.ts
+               source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.ts
                 ^
-                source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                  ^
-                 source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                 source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                   ^
-                  source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts
+                  source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts
                    ^^
-                   source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts storage.type.function.arrow.ts
+                   source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts storage.type.function.arrow.ts
                      ^
-                     source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts
+                     source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts
                       ^^^
-                      source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts support.type.primitive.ts
+                      source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts support.type.primitive.ts
                          ^
                          source.ts cast.expr.ts meta.object.type.ts punctuation.definition.block.ts
                           ^
@@ -135,35 +135,35 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts cast.expr.ts meta.object.type.ts punctuation.definition.block.ts
          ^
-         source.ts cast.expr.ts meta.object.type.ts meta.indexer.declaration.ts meta.brace.square.ts
+         source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.array.literal.ts meta.brace.square.ts
           ^^^
-          source.ts cast.expr.ts meta.object.type.ts meta.indexer.declaration.ts meta.indexer.parameter.ts variable.parameter.ts
+          source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.array.literal.ts variable.other.readwrite.ts
              ^
-             source.ts cast.expr.ts meta.object.type.ts meta.indexer.declaration.ts meta.brace.square.ts
+             source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.array.literal.ts meta.brace.square.ts
               ^
-              source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+              source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                ^
-               source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.ts
+               source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.ts
                 ^
-                source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                  ^
-                 source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                 source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                   ^
-                  source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts
+                  source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts
                    ^^
-                   source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts storage.type.function.arrow.ts
+                   source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts storage.type.function.arrow.ts
                      ^
-                     source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts punctuation.definition.block.ts
+                     source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts punctuation.definition.block.ts
                       ^
-                      source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
+                      source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                        ^
-                       source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+                       source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                         ^
-                        source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts
+                        source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts
                          ^^^^^^
-                         source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts support.type.primitive.ts
+                         source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts support.type.primitive.ts
                                ^
-                               source.ts cast.expr.ts meta.object.type.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts punctuation.definition.block.ts
+                               source.ts cast.expr.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.function.return.ts meta.object.type.ts punctuation.definition.block.ts
                                 ^
                                 source.ts cast.expr.ts meta.object.type.ts punctuation.definition.block.ts
                                  ^

--- a/tests/baselines/Issue90.baseline.txt
+++ b/tests/baselines/Issue90.baseline.txt
@@ -21,11 +21,11 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+        source.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+         source.ts meta.var.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts
            ^
            source.ts punctuation.terminator.statement.ts
 > var b = 1;
@@ -40,11 +40,11 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+        source.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+         source.ts meta.var.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts
            ^
            source.ts punctuation.terminator.statement.ts
 > var c = a ^ b;
@@ -59,19 +59,19 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+        source.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+         source.ts meta.var.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+          source.ts meta.var.expr.ts variable.other.readwrite.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.var.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.bitwise.ts
+            source.ts meta.var.expr.ts keyword.operator.bitwise.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+              source.ts meta.var.expr.ts variable.other.readwrite.ts
                ^
                source.ts punctuation.terminator.statement.ts
 >

--- a/tests/baselines/Issue90.txt
+++ b/tests/baselines/Issue90.txt
@@ -18,18 +18,18 @@ Grammar: TypeScript.tmLanguage
       ^
       [2, 6]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
           ^
-          [2, 10]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts 
+          [2, 10]: source.ts meta.var.expr.ts constant.numeric.decimal.ts 
 > var c = a ^ b;
  ^
  [3, 1]: source.ts 
       ^
       [3, 6]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
           ^
-          [3, 10]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
+          [3, 10]: source.ts meta.var.expr.ts variable.other.readwrite.ts 
             ^
-            [3, 12]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.bitwise.ts 
+            [3, 12]: source.ts meta.var.expr.ts keyword.operator.bitwise.ts 
               ^
-              [3, 14]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts 
+              [3, 14]: source.ts meta.var.expr.ts variable.other.readwrite.ts 
 >
  ^
  [4, 1]: source.ts 

--- a/tests/baselines/Issue96.baseline.txt
+++ b/tests/baselines/Issue96.baseline.txt
@@ -60,11 +60,11 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                 source.ts meta.var.expr.ts constant.numeric.decimal.ts
                    ^
                    source.ts punctuation.terminator.statement.ts
 >constenum += 10;
@@ -112,15 +112,15 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                source.ts meta.var.expr.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                 source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                   ^^^^^^^^^^^^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                  source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                    ^
                                    source.ts punctuation.terminator.statement.ts
 >constable += " Royal, I say!";

--- a/tests/baselines/TsxSamples.baseline.txt
+++ b/tests/baselines/TsxSamples.baseline.txt
@@ -195,7 +195,7 @@ Grammar: TypeScriptReact.tmLanguage
         ^
         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+         source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
 >    <Form>
  ^^^^
  source.tsx
@@ -291,96 +291,96 @@ Grammar: TypeScriptReact.tmLanguage
          ^
          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
           ^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+          source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
            ^
-           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+           source.tsx meta.var.expr.tsx
             ^
-            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+            source.tsx meta.var.expr.tsx meta.brace.round.tsx
 >    <Form>
  ^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+ source.tsx meta.var.expr.tsx
      ^
-     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+     source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
       ^^^^
-      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
           ^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >        <FormRow>
  ^^^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
           ^^^^^^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                  ^
-                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >            <FormLabel data='1' />
  ^^^^^^^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
               ^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
                         ^^^^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
                             ^
-                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
                               ^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
                                 ^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
+                                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
                                  ^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >            <FormInput data='2' />
  ^^^^^^^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
               ^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
                         ^^^^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
                             ^
-                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
                               ^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
+                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
                                 ^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
+                                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
                                  ^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >        </FormRow>
  ^^^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
          ^^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
            ^^^^^^^
-           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                   ^
-                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >      </Form>
  ^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
        ^^
-       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
          ^^^^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >)
  ^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+ source.tsx meta.var.expr.tsx meta.brace.round.tsx
 >
  ^
  source.tsx
@@ -394,95 +394,95 @@ Grammar: TypeScriptReact.tmLanguage
             ^
             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+             source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+              source.tsx meta.var.expr.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+               source.tsx meta.var.expr.tsx meta.brace.round.tsx
 >    <Nav>
  ^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+ source.tsx meta.var.expr.tsx
      ^
-     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+     source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
       ^^^
-      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >        {/* child comment, put {} around */}
  ^^^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
           ^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx
+            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx
                                           ^^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
+                                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
                                             ^
-                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
 >        <Person name={window.isLoggedIn ? window.name : ''}
  ^^^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
           ^^^^^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
                 ^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx
                  ^^^^
-                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
                      ^
-                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                     source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx keyword.operator.assignment.tsx
                       ^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                        ^^^^^^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx
+                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
+                             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                               ^^^^^^^^^^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.property.tsx
+                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                         ^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
+                                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                          ^
-                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.ternary.tsx
+                                         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.ternary.tsx
                                           ^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
+                                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                            ^^^^^^
-                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx
+                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx
                                                  ^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
+                                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                                   ^^^^
-                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.property.dom.tsx
+                                                  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.property.dom.tsx
                                                       ^
-                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
+                                                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                                        ^
-                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.ternary.tsx
+                                                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.ternary.tsx
                                                         ^
-                                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
+                                                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx
                                                          ^
-                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                           ^
-                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                            ^
-                                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
 >        />
  ^^^^^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
          ^^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >    </Nav>
  ^^^^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+ source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
      ^^
-     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+     source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
        ^^^
-       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
           ^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >);
  ^
- source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.brace.round.tsx
+ source.tsx meta.var.expr.tsx meta.brace.round.tsx
   ^
   source.tsx punctuation.terminator.statement.tsx
 >
@@ -508,13 +508,13 @@ Grammar: TypeScriptReact.tmLanguage
           ^
           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
            ^
-           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+           source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
             ^
-            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+            source.tsx meta.var.expr.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+             source.tsx meta.var.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+              source.tsx meta.var.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
                ^
                source.tsx punctuation.terminator.statement.tsx
 >props.foo = x;
@@ -561,27 +561,27 @@ Grammar: TypeScriptReact.tmLanguage
               ^
               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+               source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
                 ^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                source.tsx meta.var.expr.tsx
                  ^
-                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                 source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
                   ^^^^^^^^^
-                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx
+                  source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx
                            ^
-                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
+                           source.tsx meta.var.expr.tsx meta.tag.tsx
                             ^
-                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                              ^^^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx
+                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx
                                 ^^^^^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
+                                source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                                      ^
-                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                     source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                       ^
-                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
+                                      source.tsx meta.var.expr.tsx meta.tag.tsx
                                        ^^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                       source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
                                          ^
                                          source.tsx punctuation.terminator.statement.tsx
 >
@@ -597,29 +597,29 @@ Grammar: TypeScriptReact.tmLanguage
            ^
            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
             ^
-            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+            source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+             source.tsx meta.var.expr.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+              source.tsx meta.var.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx
+               source.tsx meta.var.expr.tsx meta.object-literal.tsx
                 ^^^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx
+                source.tsx meta.var.expr.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx
                    ^
-                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx punctuation.separator.key-value.tsx
+                   source.tsx meta.var.expr.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx punctuation.separator.key-value.tsx
                     ^
-                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx meta.object.member.tsx
+                    source.tsx meta.var.expr.tsx meta.object-literal.tsx meta.object.member.tsx
                      ^
-                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                     source.tsx meta.var.expr.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                       ^^^^^^^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx
+                      source.tsx meta.var.expr.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                             source.tsx meta.var.expr.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                               ^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx meta.object.member.tsx
+                              source.tsx meta.var.expr.tsx meta.object-literal.tsx meta.object.member.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+                               source.tsx meta.var.expr.tsx meta.object-literal.tsx punctuation.definition.block.tsx
 >var component2 = <Component {...props} foo={'override'} />
  ^^^
  source.tsx meta.var.expr.tsx storage.type.tsx
@@ -630,43 +630,43 @@ Grammar: TypeScriptReact.tmLanguage
                ^
                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
                 ^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+                source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
                  ^
-                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+                 source.tsx meta.var.expr.tsx
                   ^
-                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+                  source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
                    ^^^^^^^^^
-                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx
+                   source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx
                             ^
-                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
+                            source.tsx meta.var.expr.tsx meta.tag.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                               ^^^
-                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx
+                              source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx
                                  ^^^^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
+                                 source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                                       ^
-                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                        ^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx
                                         ^^^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
                                            ^
-                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                                           source.tsx meta.var.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
                                             ^
-                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                                              ^
-                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                               ^^^^^^^^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx
+                                              source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                                                       ^
-                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                        ^
-                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                         ^
-                                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
+                                                        source.tsx meta.var.expr.tsx meta.tag.tsx
                                                          ^^
-                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                         source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >
  ^
  source.tsx
@@ -690,35 +690,35 @@ Grammar: TypeScriptReact.tmLanguage
       ^
       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
        ^
-       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+       source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
         ^
-        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+        source.tsx meta.var.expr.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
           ^^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                 ^^^^^^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
+                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                       ^^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx constant.character.escape.tsx
+                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx constant.character.escape.tsx
                         ^^^^^^^^^^^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
+                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                                    ^
-                                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                   source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                     ^
-                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                    source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                      ^^
-                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                     source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                        ^^^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                           ^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >var b = <div>{'First ' + String.fromCharCode(183) + ' Second'}</div>
  ^^^
  source.tsx meta.var.expr.tsx storage.type.tsx
@@ -729,61 +729,61 @@ Grammar: TypeScriptReact.tmLanguage
       ^
       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
        ^
-       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+       source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
         ^
-        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+        source.tsx meta.var.expr.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
           ^^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                 ^^^^^^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
+                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                       ^
-                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
+                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                         ^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx keyword.operator.arithmetic.tsx
+                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx keyword.operator.arithmetic.tsx
                          ^
-                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
+                         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                           ^^^^^^
-                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.class.builtin.tsx
+                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.class.builtin.tsx
                                 ^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
+                                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.accessor.tsx
                                  ^^^^^^^^^^^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.function.tsx
+                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.function.tsx
                                              ^
-                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
+                                             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
                                               ^^^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx constant.numeric.decimal.tsx
+                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx constant.numeric.decimal.tsx
                                                  ^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
+                                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
                                                   ^
-                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
+                                                  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                                                    ^
-                                                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx keyword.operator.arithmetic.tsx
+                                                   source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx keyword.operator.arithmetic.tsx
                                                     ^
-                                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
+                                                    source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
                                                      ^
-                                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                     source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                       ^^^^^^^
-                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
+                                                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx
                                                              ^
-                                                             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                               ^
-                                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                                ^^
-                                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                                  ^^^
-                                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                                                     ^
-                                                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                    source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >var c = <div>{['First ', <span>&middot;</span>, ' Second']}</div>
  ^^^
  source.tsx meta.var.expr.tsx storage.type.tsx
@@ -794,67 +794,67 @@ Grammar: TypeScriptReact.tmLanguage
       ^
       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
        ^
-       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+       source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
         ^
-        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+        source.tsx meta.var.expr.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
           ^^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                ^
-               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
+               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                 ^
-                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                  ^^^^^^
-                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx
+                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                         ^
-                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
+                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
                          ^
-                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx
+                         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx
                           ^
-                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                            ^^^^
-                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                                 ^
-                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
+                                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
                                  ^^^^^^
-                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx
+                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx
                                        ^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
+                                       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx constant.character.entity.tsx punctuation.definition.entity.tsx
                                         ^^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                           ^^^^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                               ^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
                                                ^
-                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
+                                               source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx punctuation.separator.comma.tsx
                                                 ^
-                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx
+                                                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx
                                                  ^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                   ^^^^^^^
-                                                  source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx
+                                                  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx
                                                          ^
-                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                           ^
-                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
+                                                          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                                                            ^
-                                                           source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                             ^^
-                                                            source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                                                            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                               ^^^
-                                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
                                                                  ^
-                                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                                                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >var d = <div dangerouslySetInnerHTML={{__html: 'First &middot; Second'}} />
  ^^^
  source.tsx meta.var.expr.tsx storage.type.tsx
@@ -865,43 +865,43 @@ Grammar: TypeScriptReact.tmLanguage
       ^
       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
        ^
-       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+       source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
         ^
-        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+        source.tsx meta.var.expr.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
           ^^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx
               ^^^^^^^^^^^^^^^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+              source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
                                      ^
-                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                                     source.tsx meta.var.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
                                       ^
-                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
                                        ^
-                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx punctuation.definition.block.tsx
                                         ^^^^^^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx
+                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx
                                               ^
-                                              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx punctuation.separator.key-value.tsx
+                                              source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx punctuation.separator.key-value.tsx
                                                ^
-                                               source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx
+                                               source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx
                                                 ^
-                                                source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
+                                                source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                                  ^^^^^^^^^^^^^^^^^^^^^
-                                                 source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx
+                                                 source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx
                                                                       ^
-                                                                      source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
+                                                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                                        ^
-                                                                       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx punctuation.definition.block.tsx
+                                                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx punctuation.definition.block.tsx
                                                                         ^
-                                                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
                                                                          ^
-                                                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
+                                                                         source.tsx meta.var.expr.tsx meta.tag.tsx
                                                                           ^^
-                                                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                                                          source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >var e = <div data-custom-attribute="foo" />
  ^^^
  source.tsx meta.var.expr.tsx storage.type.tsx
@@ -912,29 +912,29 @@ Grammar: TypeScriptReact.tmLanguage
       ^
       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
        ^
-       source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx keyword.operator.assignment.tsx
+       source.tsx meta.var.expr.tsx keyword.operator.assignment.tsx
         ^
-        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx
+        source.tsx meta.var.expr.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
           ^^^
-          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx
              ^
-             source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx
+             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx
               ^^^^^^^^^^^^^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
+              source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx
                                    ^
-                                   source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
+                                   source.tsx meta.var.expr.tsx meta.tag.tsx keyword.operator.assignment.tsx
                                     ^
-                                    source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
+                                    source.tsx meta.var.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx punctuation.definition.string.jsxAttributeValue.begin.tsx
                                      ^^^
-                                     source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx
+                                     source.tsx meta.var.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx
                                         ^
-                                        source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
+                                        source.tsx meta.var.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx punctuation.definition.string.jsxAttributeValue.end.tsx
                                          ^
-                                         source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx
+                                         source.tsx meta.var.expr.tsx meta.tag.tsx
                                           ^^
-                                          source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+                                          source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >
  ^
  source.tsx

--- a/tests/baselines/TsxSamples.txt
+++ b/tests/baselines/TsxSamples.txt
@@ -122,66 +122,66 @@ Grammar: TypeScriptReact.tmLanguage
 >var App2 = (
 >    <Form>
      ^
-     [21, 5]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+     [21, 5]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
       ^^^^
-      [21, 6]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+      [21, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
 >        <FormRow>
          ^
-         [22, 9]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+         [22, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
           ^^^^^^^
-          [22, 10]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+          [22, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
 >            <FormLabel data='1' />
              ^
-             [23, 13]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
+             [23, 13]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
               ^^^^^^^^^
-              [23, 14]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+              [23, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
                         ^^^^
-                        [23, 24]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
+                        [23, 24]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
                               ^
-                              [23, 30]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx 
+                              [23, 30]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx 
 >            <FormInput data='2' />
              ^
-             [24, 13]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
+             [24, 13]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
               ^^^^^^^^^
-              [24, 14]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+              [24, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
                         ^^^^
-                        [24, 24]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
+                        [24, 24]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
                               ^
-                              [24, 30]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx 
+                              [24, 30]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx string.jsxAttributeValue.quoted.single.tsx 
 >        </FormRow>
          ^^
-         [25, 9]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+         [25, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
            ^^^^^^^
-           [25, 11]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+           [25, 11]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
 >      </Form>
        ^^
-       [26, 7]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+       [26, 7]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
          ^^^^
-         [26, 9]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+         [26, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
 >)
 >
 >var content = (
 >    <Nav>
      ^
-     [30, 5]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+     [30, 5]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
       ^^^
-      [30, 6]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+      [30, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
 >        {/* child comment, put {} around */}
 >        <Person name={window.isLoggedIn ? window.name : ''}
          ^
-         [32, 9]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
+         [32, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
           ^^^^^^
-          [32, 10]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+          [32, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
                  ^^^^
-                 [32, 17]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
+                 [32, 17]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attribute-name.tsx entity.other.attribute-name.tsx 
                        ^^^^^^
-                       [32, 23]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx 
+                       [32, 23]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.embedded.expression.tsx support.variable.dom.tsx 
 >        />
          ^^
-         [33, 9]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
+         [33, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
 >    </Nav>
      ^^
-     [34, 5]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+     [34, 5]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
 >);
 >
 >// JSX Spread Attributes
@@ -191,42 +191,42 @@ Grammar: TypeScriptReact.tmLanguage
 >props.bar = y;
 >var component = <Component {...props} />;
                  ^
-                 [42, 17]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
+                 [42, 17]: source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
                   ^^^^^^^^^
-                  [42, 18]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx 
+                  [42, 18]: source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx 
                              ^^^
-                             [42, 29]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx 
+                             [42, 29]: source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx 
                                        ^^
-                                       [42, 39]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
+                                       [42, 39]: source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
 >
 >var props2 = { foo: 'default' }
 >var component2 = <Component {...props} foo={'override'} />
                   ^
-                  [45, 18]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
+                  [45, 18]: source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
                    ^^^^^^^^^
-                   [45, 19]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx entity.name.tag.tsx 
+                   [45, 19]: source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx 
                               ^^^
-                              [45, 30]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx 
+                              [45, 30]: source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx 
                                                          ^^
-                                                         [45, 57]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
+                                                         [45, 57]: source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx 
 >
 >// JSX Gotchas
 >// http://facebook.github.io/react/docs/jsx-gotchas.html
 >var a = <div>{'First \u00b7 Second'}</div>
                ^
-               [49, 15]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
+               [49, 15]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
 >var b = <div>{'First ' + String.fromCharCode(183) + ' Second'}</div>
                           ^^^^^^
-                          [50, 26]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.class.builtin.tsx 
+                          [50, 26]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.class.builtin.tsx 
 >var c = <div>{['First ', <span>&middot;</span>, ' Second']}</div>
                           ^
-                          [51, 26]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
+                          [51, 26]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
 >var d = <div dangerouslySetInnerHTML={{__html: 'First &middot; Second'}} />
                                         ^^^^^^
-                                        [52, 40]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx 
+                                        [52, 40]: source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx meta.object-literal.key.tsx 
                                                 ^
-                                                [52, 48]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
+                                                [52, 48]: source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx meta.object-literal.tsx meta.object.member.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx 
 >var e = <div data-custom-attribute="foo" />
                                      ^^^
-                                     [53, 37]: source.tsx meta.var.expr.tsx meta.var-single-variable.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx 
+                                     [53, 37]: source.tsx meta.var.expr.tsx meta.tag.tsx string.jsxAttributeValue.quoted.double.tsx 
 >

--- a/tests/baselines/arrow.baseline.txt
+++ b/tests/baselines/arrow.baseline.txt
@@ -23,30 +23,30 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.modifier.async.ts
+         source.ts meta.var.expr.ts meta.arrow.ts storage.modifier.async.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+              source.ts meta.var.expr.ts meta.arrow.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts variable.parameter.ts
+               source.ts meta.var.expr.ts meta.arrow.ts variable.parameter.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                source.ts meta.var.expr.ts meta.arrow.ts
                  ^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                 source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                   source.ts meta.var.expr.ts meta.arrow.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                    source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+                     source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
 >}
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
   ^
-  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+  source.ts meta.var.expr.ts
 >class C {
  ^^^^^
  source.ts meta.class.ts storage.type.class.ts

--- a/tests/baselines/awaitUsedInExpression.baseline.txt
+++ b/tests/baselines/awaitUsedInExpression.baseline.txt
@@ -15,22 +15,22 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^^^^^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.control.flow.ts
+              source.ts meta.var.expr.ts keyword.control.flow.ts
                    ^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                   source.ts meta.var.expr.ts
                     ^^^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.object.ts
+                    source.ts meta.var.expr.ts variable.other.object.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                       source.ts meta.var.expr.ts punctuation.accessor.ts
                         ^^^^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                        source.ts meta.var.expr.ts entity.name.function.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                            source.ts meta.var.expr.ts meta.brace.round.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                             source.ts meta.var.expr.ts meta.brace.round.ts
                               ^
                               source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/binder.baseline.txt
+++ b/tests/baselines/binder.baseline.txt
@@ -170,29 +170,29 @@ Grammar: TypeScript.tmLanguage
                                         ^
                                         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                                          ^
-                                         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                         source.ts meta.function.ts meta.block.ts meta.var.expr.ts keyword.operator.assignment.ts
                                           ^
-                                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts
                                            ^
-                                           source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                           source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                                             ^
-                                            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                                            source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts
                                              ^^^^^
-                                             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                                             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                                                   ^
-                                                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                                                  source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                                                    ^
-                                                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                                                   source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                                                     ^^^^^^^^^
-                                                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
+                                                    source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.object.ts
                                                              ^
-                                                             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
+                                                             source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts punctuation.accessor.ts
                                                               ^^^^^^^^^^^
-                                                              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
+                                                              source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.property.ts
                                                                          ^
-                                                                         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                                                                         source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                                                                           ^
-                                                                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                                                                          source.ts meta.function.ts meta.block.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                                                                            ^
                                                                            source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                                                                             ^^

--- a/tests/baselines/constants.baseline.txt
+++ b/tests/baselines/constants.baseline.txt
@@ -21,11 +21,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.true.ts
+         source.ts meta.var.expr.ts constant.language.boolean.true.ts
              ^
              source.ts punctuation.terminator.statement.ts
               ^^
@@ -40,11 +40,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.boolean.false.ts
+         source.ts meta.var.expr.ts constant.language.boolean.false.ts
               ^
               source.ts punctuation.terminator.statement.ts
                ^^
@@ -59,11 +59,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.undefined.ts
+         source.ts meta.var.expr.ts constant.language.undefined.ts
                   ^
                   source.ts punctuation.terminator.statement.ts
                    ^^
@@ -78,11 +78,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.nan.ts
+         source.ts meta.var.expr.ts constant.language.nan.ts
             ^
             source.ts punctuation.terminator.statement.ts
              ^^
@@ -97,13 +97,13 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+         source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
           ^^^^^^^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.infinity.ts
+          source.ts meta.var.expr.ts constant.language.infinity.ts
                   ^
                   source.ts punctuation.terminator.statement.ts
                    ^^
@@ -118,13 +118,13 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.arithmetic.ts
+         source.ts meta.var.expr.ts keyword.operator.arithmetic.ts
           ^^^^^^^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.infinity.ts
+          source.ts meta.var.expr.ts constant.language.infinity.ts
                   ^
                   source.ts punctuation.terminator.statement.ts
                    ^^
@@ -139,10 +139,10 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.language.infinity.ts
+         source.ts meta.var.expr.ts constant.language.infinity.ts
                  ^
                  source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/destructuringWithDefaults.baseline.txt
+++ b/tests/baselines/destructuringWithDefaults.baseline.txt
@@ -1,0 +1,470 @@
+original file
+-----------------------------------
+interface IOptions {
+    check: boolean;
+    files: string;
+    primary: string;
+}
+var {
+    check: isReportMode = false,
+    files = '**/locals/*.json',
+    primary: primaryLanguage = 'en'
+}: IOptions = null;
+function sync({
+    check: isReportMode = false,
+    files = '**/locals/*.json',
+    primary: primaryLanguage = 'en'
+}: IOptions) {
+}
+
+var [
+    check2 = false,
+    files2 = '**/locals/*.json',
+    primary2 = 'en'
+] = [];
+function sync2([
+    check2 = false,
+    files2 = '**/locals/*.json',
+    primary2 = 'en'
+]) {
+}
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>interface IOptions {
+ ^^^^^^^^^
+ source.ts meta.class.ts storage.type.interface.ts
+          ^
+          source.ts meta.class.ts
+           ^^^^^^^^
+           source.ts meta.class.ts entity.name.class.ts
+                   ^
+                   source.ts meta.class.ts
+                    ^
+                    source.ts meta.class.ts punctuation.definition.block.ts
+                     ^^
+                     source.ts meta.class.ts
+>    check: boolean;
+ ^^^^
+ source.ts meta.class.ts meta.field.declaration.ts
+     ^^^^^
+     source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
+          ^
+          source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+           ^
+           source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts
+            ^^^^^^^
+            source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts support.type.primitive.ts
+                   ^
+                   source.ts meta.class.ts punctuation.terminator.statement.ts
+                    ^^
+                    source.ts meta.class.ts
+>    files: string;
+ ^^^^
+ source.ts meta.class.ts meta.field.declaration.ts
+     ^^^^^
+     source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
+          ^
+          source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+           ^
+           source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts
+            ^^^^^^
+            source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts support.type.primitive.ts
+                  ^
+                  source.ts meta.class.ts punctuation.terminator.statement.ts
+                   ^^
+                   source.ts meta.class.ts
+>    primary: string;
+ ^^^^
+ source.ts meta.class.ts meta.field.declaration.ts
+     ^^^^^^^
+     source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
+            ^
+            source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+             ^
+             source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts
+              ^^^^^^
+              source.ts meta.class.ts meta.field.declaration.ts meta.type.annotation.ts support.type.primitive.ts
+                    ^
+                    source.ts meta.class.ts punctuation.terminator.statement.ts
+                     ^^
+                     source.ts meta.class.ts
+>}
+ ^
+ source.ts meta.class.ts punctuation.definition.block.ts
+  ^^
+  source.ts
+>var {
+ ^^^
+ source.ts meta.var.expr.ts storage.type.ts
+    ^
+    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+     ^
+     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.definition.binding-pattern.object.ts
+      ^^
+      source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+>    check: isReportMode = false,
+ ^^^^
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+     ^^^^^
+     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.object.property.ts
+          ^
+          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.destructuring.ts
+           ^
+           source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+            ^^^^^^^^^^^^
+            source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.other.readwrite.ts
+                        ^
+                        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+                         ^
+                         source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+                          ^
+                          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+                           ^^^^^
+                           source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts constant.language.boolean.false.ts
+                                ^
+                                source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.separator.comma.ts
+                                 ^^
+                                 source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+>    files = '**/locals/*.json',
+ ^^^^
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+     ^^^^^
+     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.other.readwrite.ts
+          ^
+          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+           ^
+           source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+            ^
+            source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+             ^
+             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+              ^^^^^^^^^^^^^^^^
+              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts string.quoted.single.ts
+                              ^
+                              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                               ^
+                               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.separator.comma.ts
+                                ^^
+                                source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+>    primary: primaryLanguage = 'en'
+ ^^^^
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+     ^^^^^^^
+     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.object.property.ts
+            ^
+            source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.destructuring.ts
+             ^
+             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+              ^^^^^^^^^^^^^^^
+              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.other.readwrite.ts
+                             ^
+                             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+                              ^
+                              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+                               ^
+                               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+                                ^
+                                source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                 ^^
+                                 source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts string.quoted.single.ts
+                                   ^
+                                   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                    ^
+                                    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+>}: IOptions = null;
+ ^
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts punctuation.definition.binding-pattern.object.ts
+  ^
+  source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+   ^
+   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts
+    ^^^^^^^^
+    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts entity.name.type.ts
+            ^
+            source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts
+             ^
+             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+              ^
+              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+               ^^^^
+               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts constant.language.null.ts
+                   ^
+                   source.ts punctuation.terminator.statement.ts
+                    ^^
+                    source.ts
+>function sync({
+ ^^^^^^^^
+ source.ts meta.function.ts storage.type.function.ts
+         ^
+         source.ts meta.function.ts
+          ^^^^
+          source.ts meta.function.ts entity.name.function.ts
+              ^
+              source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+               ^
+               source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.definition.binding-pattern.object.ts
+                ^^
+                source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+>    check: isReportMode = false,
+ ^^^^
+ source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+     ^^^^^
+     source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts variable.object.property.ts
+          ^
+          source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.destructuring.ts
+           ^
+           source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+            ^^^^^^^^^^^^
+            source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts variable.parameter.ts
+                        ^
+                        source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+                         ^
+                         source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts keyword.operator.assignment.ts
+                          ^
+                          source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+                           ^^^^^
+                           source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts constant.language.boolean.false.ts
+                                ^
+                                source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.separator.comma.ts
+                                 ^^
+                                 source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+>    files = '**/locals/*.json',
+ ^^^^
+ source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+     ^^^^^
+     source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts variable.parameter.ts
+          ^
+          source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+           ^
+           source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts keyword.operator.assignment.ts
+            ^
+            source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+             ^
+             source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+              ^^^^^^^^^^^^^^^^
+              source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts string.quoted.single.ts
+                              ^
+                              source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                               ^
+                               source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.separator.comma.ts
+                                ^^
+                                source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+>    primary: primaryLanguage = 'en'
+ ^^^^
+ source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+     ^^^^^^^
+     source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts variable.object.property.ts
+            ^
+            source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.destructuring.ts
+             ^
+             source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+              ^^^^^^^^^^^^^^^
+              source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts variable.parameter.ts
+                             ^
+                             source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+                              ^
+                              source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts keyword.operator.assignment.ts
+                               ^
+                               source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+                                ^
+                                source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                 ^^
+                                 source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts string.quoted.single.ts
+                                   ^
+                                   source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                    ^
+                                    source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts
+>}: IOptions) {
+ ^
+ source.ts meta.function.ts meta.parameters.ts meta.parameter.object-binding-pattern.ts punctuation.definition.binding-pattern.object.ts
+  ^
+  source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+   ^
+   source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts
+    ^^^^^^^^
+    source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+            ^
+            source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+             ^
+             source.ts meta.function.ts
+              ^
+              source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+               ^^
+               source.ts meta.function.ts meta.block.ts
+>}
+ ^
+ source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+  ^^
+  source.ts
+>
+ ^^
+ source.ts
+>var [
+ ^^^
+ source.ts meta.var.expr.ts storage.type.ts
+    ^
+    source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+     ^
+     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts punctuation.definition.binding-pattern.array.ts
+      ^^
+      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+>    check2 = false,
+ ^^^^
+ source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+     ^^^^^^
+     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts variable.other.readwrite.ts
+           ^
+           source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+            ^
+            source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+             ^
+             source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+              ^^^^^
+              source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts constant.language.boolean.false.ts
+                   ^
+                   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts punctuation.separator.comma.ts
+                    ^^
+                    source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+>    files2 = '**/locals/*.json',
+ ^^^^
+ source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+     ^^^^^^
+     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts variable.other.readwrite.ts
+           ^
+           source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+            ^
+            source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+             ^
+             source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+              ^
+              source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+               ^^^^^^^^^^^^^^^^
+               source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts
+                               ^
+                               source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                ^
+                                source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts punctuation.separator.comma.ts
+                                 ^^
+                                 source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+>    primary2 = 'en'
+ ^^^^
+ source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+     ^^^^^^^^
+     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts variable.other.readwrite.ts
+             ^
+             source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+              ^
+              source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+               ^
+               source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+                ^
+                source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                 ^^
+                 source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts
+                   ^
+                   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                    ^
+                    source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+>] = [];
+ ^
+ source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts punctuation.definition.binding-pattern.array.ts
+  ^
+  source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+   ^
+   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+    ^
+    source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+     ^
+     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts meta.brace.square.ts
+      ^
+      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts meta.brace.square.ts
+       ^
+       source.ts punctuation.terminator.statement.ts
+        ^^
+        source.ts
+>function sync2([
+ ^^^^^^^^
+ source.ts meta.function.ts storage.type.function.ts
+         ^
+         source.ts meta.function.ts
+          ^^^^^
+          source.ts meta.function.ts entity.name.function.ts
+               ^
+               source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                ^
+                source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts punctuation.definition.binding-pattern.array.ts
+                 ^^
+                 source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+>    check2 = false,
+ ^^^^
+ source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+     ^^^^^^
+     source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts variable.parameter.ts
+           ^
+           source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+            ^
+            source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts keyword.operator.assignment.ts
+             ^
+             source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+              ^^^^^
+              source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts constant.language.boolean.false.ts
+                   ^
+                   source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts punctuation.separator.comma.ts
+                    ^^
+                    source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+>    files2 = '**/locals/*.json',
+ ^^^^
+ source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+     ^^^^^^
+     source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts variable.parameter.ts
+           ^
+           source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+            ^
+            source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts keyword.operator.assignment.ts
+             ^
+             source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+              ^
+              source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+               ^^^^^^^^^^^^^^^^
+               source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts string.quoted.single.ts
+                               ^
+                               source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                ^
+                                source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts punctuation.separator.comma.ts
+                                 ^^
+                                 source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+>    primary2 = 'en'
+ ^^^^
+ source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+     ^^^^^^^^
+     source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts variable.parameter.ts
+             ^
+             source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+              ^
+              source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts keyword.operator.assignment.ts
+               ^
+               source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+                ^
+                source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                 ^^
+                 source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts string.quoted.single.ts
+                   ^
+                   source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                    ^
+                    source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts
+>]) {
+ ^
+ source.ts meta.function.ts meta.parameters.ts meta.paramter.array-binding-pattern.ts punctuation.definition.binding-pattern.array.ts
+  ^
+  source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+   ^
+   source.ts meta.function.ts
+    ^
+    source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+     ^^
+     source.ts meta.function.ts meta.block.ts
+>}
+ ^
+ source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts

--- a/tests/baselines/destructuringWithDefaults.baseline.txt
+++ b/tests/baselines/destructuringWithDefaults.baseline.txt
@@ -185,11 +185,11 @@ Grammar: TypeScript.tmLanguage
             ^
             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts
              ^
-             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+             source.ts meta.var.expr.ts keyword.operator.assignment.ts
               ^
-              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+              source.ts meta.var.expr.ts
                ^^^^
-               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts constant.language.null.ts
+               source.ts meta.var.expr.ts constant.language.null.ts
                    ^
                    source.ts punctuation.terminator.statement.ts
                     ^^
@@ -373,13 +373,13 @@ Grammar: TypeScript.tmLanguage
   ^
   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
    ^
-   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+   source.ts meta.var.expr.ts keyword.operator.assignment.ts
     ^
-    source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+    source.ts meta.var.expr.ts
      ^
-     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts meta.brace.square.ts
+     source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
       ^
-      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts meta.brace.square.ts
+      source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
        ^
        source.ts punctuation.terminator.statement.ts
         ^^

--- a/tests/baselines/destructuringWithDefaults.baseline.txt
+++ b/tests/baselines/destructuringWithDefaults.baseline.txt
@@ -47,7 +47,7 @@ Grammar: TypeScript.tmLanguage
                      source.ts meta.class.ts
 >    check: boolean;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^^^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -62,7 +62,7 @@ Grammar: TypeScript.tmLanguage
                     source.ts meta.class.ts
 >    files: string;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^^^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -77,7 +77,7 @@ Grammar: TypeScript.tmLanguage
                    source.ts meta.class.ts
 >    primary: string;
  ^^^^
- source.ts meta.class.ts meta.field.declaration.ts
+ source.ts meta.class.ts
      ^^^^^^^
      source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
             ^

--- a/tests/baselines/generator.baseline.txt
+++ b/tests/baselines/generator.baseline.txt
@@ -327,11 +327,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts keyword.generator.asterisk.ts
+     source.ts meta.class.ts meta.method.declaration.ts keyword.generator.asterisk.ts
       ^
-      source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+      source.ts meta.class.ts meta.method.declaration.ts
        ^^^^^^^^
-       source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+       source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                ^
                source.ts meta.class.ts meta.method.declaration.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                 ^
@@ -356,11 +356,11 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts
      ^
-     source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts keyword.generator.asterisk.ts
+     source.ts meta.class.ts meta.method.declaration.ts keyword.generator.asterisk.ts
       ^
-      source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts
+      source.ts meta.class.ts meta.method.declaration.ts
        ^^^^^^^^
-       source.ts meta.class.ts meta.method.declaration.ts meta.method.overload.declaration.ts entity.name.function.ts
+       source.ts meta.class.ts meta.method.declaration.ts entity.name.function.ts
                ^
                source.ts meta.class.ts meta.method.declaration.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                 ^

--- a/tests/baselines/generator.baseline.txt
+++ b/tests/baselines/generator.baseline.txt
@@ -174,11 +174,11 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.var.expr.ts
            ^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+           source.ts meta.var.expr.ts constant.numeric.decimal.ts
              ^
              source.ts meta.var.expr.ts punctuation.separator.comma.ts
               ^
@@ -188,11 +188,11 @@ Grammar: TypeScript.tmLanguage
                 ^
                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                 source.ts meta.var.expr.ts keyword.operator.assignment.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                  source.ts meta.var.expr.ts
                    ^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+                   source.ts meta.var.expr.ts constant.numeric.decimal.ts
                      ^
                      source.ts punctuation.terminator.statement.ts
                       ^^

--- a/tests/baselines/multipleVariableDeclaration.baseline.txt
+++ b/tests/baselines/multipleVariableDeclaration.baseline.txt
@@ -39,11 +39,11 @@ Grammar: TypeScript.tmLanguage
        ^
        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+        source.ts meta.var.expr.ts keyword.operator.assignment.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+         source.ts meta.var.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts
            ^
            source.ts meta.var.expr.ts punctuation.separator.comma.ts
             ^
@@ -53,37 +53,37 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                source.ts meta.var.expr.ts keyword.operator.assignment.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.var.expr.ts
                   ^^^^^^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts storage.type.function.ts
+                  source.ts meta.var.expr.ts meta.function.ts storage.type.function.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts
+                          source.ts meta.var.expr.ts meta.function.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                           source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
+                            source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts variable.parameter.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                             source.ts meta.var.expr.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts
+                              source.ts meta.var.expr.ts meta.function.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                               source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+                                source.ts meta.var.expr.ts meta.function.ts meta.block.ts
                                  ^^^^^^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts keyword.control.flow.ts
+                                 source.ts meta.var.expr.ts meta.function.ts meta.block.ts keyword.control.flow.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+                                       source.ts meta.var.expr.ts meta.function.ts meta.block.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts constant.numeric.decimal.ts
+                                        source.ts meta.var.expr.ts meta.function.ts meta.block.ts constant.numeric.decimal.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
+                                         source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts
+                                          source.ts meta.var.expr.ts meta.function.ts meta.block.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                                           source.ts meta.var.expr.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
                                             ^
                                             source.ts meta.var.expr.ts punctuation.separator.comma.ts
                                              ^
@@ -93,15 +93,15 @@ Grammar: TypeScript.tmLanguage
                                                 ^
                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                                                  ^
-                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                                 source.ts meta.var.expr.ts keyword.operator.assignment.ts
                                                   ^
-                                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                                                  source.ts meta.var.expr.ts
                                                    ^
-                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                                   source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                                     ^^^^^^
-                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                                                    source.ts meta.var.expr.ts string.quoted.double.ts
                                                           ^
-                                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                                          source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >var a2: string = "test", b2: () => void = () => { console.log("hello"); }, c2: string | number;
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
@@ -118,15 +118,15 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                source.ts meta.var.expr.ts keyword.operator.assignment.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                 source.ts meta.var.expr.ts
                   ^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                  source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                    ^^^^
-                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts
+                   source.ts meta.var.expr.ts string.quoted.double.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                       source.ts meta.var.expr.ts string.quoted.double.ts punctuation.definition.string.end.ts
                         ^
                         source.ts meta.var.expr.ts punctuation.separator.comma.ts
                          ^
@@ -152,45 +152,45 @@ Grammar: TypeScript.tmLanguage
                                         ^
                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.type.function.return.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                                         source.ts meta.var.expr.ts keyword.operator.assignment.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                          source.ts meta.var.expr.ts meta.arrow.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+                                           source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                                            source.ts meta.var.expr.ts meta.arrow.ts meta.parameters.ts punctuation.definition.parameters.end.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                             source.ts meta.var.expr.ts meta.arrow.ts
                                               ^^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts storage.type.function.arrow.ts
+                                              source.ts meta.var.expr.ts meta.arrow.ts storage.type.function.arrow.ts
                                                 ^
-                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts
+                                                source.ts meta.var.expr.ts meta.arrow.ts
                                                  ^
-                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                                                 source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                                                   ^
-                                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+                                                  source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
                                                    ^^^^^^^
-                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts support.class.console.ts
+                                                   source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts support.class.console.ts
                                                           ^
-                                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
+                                                          source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.accessor.ts
                                                            ^^^
-                                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts support.function.console.ts
+                                                           source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts support.function.console.ts
                                                               ^
-                                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
+                                                              source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
                                                                ^
-                                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                                               source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                                                                 ^^^^^
-                                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts string.quoted.double.ts
+                                                                source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts string.quoted.double.ts
                                                                      ^
-                                                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                                                     source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                                                       ^
-                                                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
+                                                                      source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts meta.brace.round.ts
                                                                        ^
-                                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.terminator.statement.ts
+                                                                       source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.terminator.statement.ts
                                                                         ^
-                                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts
+                                                                        source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts
                                                                          ^
-                                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
+                                                                         source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts punctuation.definition.block.ts
                                                                           ^
                                                                           source.ts meta.var.expr.ts punctuation.separator.comma.ts
                                                                            ^
@@ -223,29 +223,29 @@ Grammar: TypeScript.tmLanguage
         ^
         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+         source.ts meta.var.expr.ts keyword.operator.assignment.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+          source.ts meta.var.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+           source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
 >	foo: "10"
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts
   ^^^
-  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+  source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
      ^
-     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
       ^
-      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.begin.ts
         ^^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts
+        source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.end.ts
+          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >}, other = 10;
  ^
- source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+ source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
   ^
   source.ts meta.var.expr.ts punctuation.separator.comma.ts
    ^
@@ -255,10 +255,10 @@ Grammar: TypeScript.tmLanguage
          ^
          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+          source.ts meta.var.expr.ts keyword.operator.assignment.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.var.expr.ts
             ^^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+            source.ts meta.var.expr.ts constant.numeric.decimal.ts
               ^
               source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/numeric.baseline.txt
+++ b/tests/baselines/numeric.baseline.txt
@@ -25,11 +25,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.hex.ts
+         source.ts meta.var.expr.ts constant.numeric.hex.ts
             ^
             source.ts punctuation.terminator.statement.ts
              ^^
@@ -44,11 +44,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.binary.ts
+         source.ts meta.var.expr.ts constant.numeric.binary.ts
             ^
             source.ts punctuation.terminator.statement.ts
              ^^
@@ -63,11 +63,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.octal.ts
+         source.ts meta.var.expr.ts constant.numeric.octal.ts
             ^
             source.ts punctuation.terminator.statement.ts
              ^^
@@ -82,15 +82,15 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
            ^^^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+           source.ts meta.var.expr.ts constant.numeric.decimal.ts
                ^
                source.ts punctuation.terminator.statement.ts
                 ^^
@@ -105,15 +105,15 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
            ^^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+           source.ts meta.var.expr.ts constant.numeric.decimal.ts
               ^
               source.ts punctuation.terminator.statement.ts
                ^^
@@ -128,13 +128,13 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
           ^^^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts
               ^
               source.ts punctuation.terminator.statement.ts
                ^^
@@ -149,11 +149,11 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^^^^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
              ^
              source.ts punctuation.terminator.statement.ts
               ^^
@@ -168,15 +168,15 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+           source.ts meta.var.expr.ts constant.numeric.decimal.ts
             ^
             source.ts punctuation.terminator.statement.ts
              ^^
@@ -191,13 +191,13 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
            ^
            source.ts punctuation.terminator.statement.ts
             ^^
@@ -212,13 +212,13 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
+         source.ts meta.var.expr.ts constant.numeric.decimal.ts meta.delimiter.decimal.period.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts
            ^
            source.ts punctuation.terminator.statement.ts
             ^^
@@ -233,10 +233,10 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts constant.numeric.decimal.ts
+          source.ts meta.var.expr.ts constant.numeric.decimal.ts
            ^
            source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/parameterBindingPattern.baseline.txt
+++ b/tests/baselines/parameterBindingPattern.baseline.txt
@@ -207,7 +207,7 @@ Grammar: TypeScript.tmLanguage
                       ^
                       source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts punctuation.definition.block.ts
                        ^
-                       source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+                       source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts
                         ^^^^^
                         source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                              ^
@@ -474,7 +474,7 @@ Grammar: TypeScript.tmLanguage
                                                            source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
 >    x: {
  ^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
      ^
      source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
       ^
@@ -487,7 +487,7 @@ Grammar: TypeScript.tmLanguage
          source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        a: number;
  ^^^^^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -502,7 +502,7 @@ Grammar: TypeScript.tmLanguage
                    source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        b: number;
  ^^^^^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -526,7 +526,7 @@ Grammar: TypeScript.tmLanguage
        source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
 >    y: {
  ^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
      ^
      source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
       ^
@@ -539,7 +539,7 @@ Grammar: TypeScript.tmLanguage
          source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        c: string;
  ^^^^^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -554,7 +554,7 @@ Grammar: TypeScript.tmLanguage
                    source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        d: string;
  ^^^^^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -578,7 +578,7 @@ Grammar: TypeScript.tmLanguage
        source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
 >    z: [number, {
  ^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts
      ^
      source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
       ^
@@ -599,7 +599,7 @@ Grammar: TypeScript.tmLanguage
                   source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts
 >        hello: string;
  ^^^^^^^^
- source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts
          ^^^^^
          source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
               ^
@@ -685,7 +685,7 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts punctuation.definition.block.ts
                ^
-               source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+               source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts
                 ^^^^^
                 source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                      ^
@@ -836,7 +836,7 @@ Grammar: TypeScript.tmLanguage
                                   ^
                                   source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts punctuation.definition.block.ts
                                    ^
-                                   source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+                                   source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts
                                     ^^^^^
                                     source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                          ^

--- a/tests/baselines/pr48_noSemiColon.baseline.txt
+++ b/tests/baselines/pr48_noSemiColon.baseline.txt
@@ -42,7 +42,7 @@ Grammar: TypeScript.tmLanguage
   ^^^^^^^
   source.ts meta.class.ts storage.modifier.ts
          ^
-         source.ts meta.class.ts meta.field.declaration.ts
+         source.ts meta.class.ts
           ^^^^
           source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
               ^
@@ -71,7 +71,7 @@ Grammar: TypeScript.tmLanguage
   ^^^^^^^
   source.ts meta.class.ts storage.modifier.ts
          ^
-         source.ts meta.class.ts meta.field.declaration.ts
+         source.ts meta.class.ts
           ^^^^^^^
           source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                  ^
@@ -96,7 +96,7 @@ Grammar: TypeScript.tmLanguage
   ^^^^^^^
   source.ts meta.class.ts storage.modifier.ts
          ^
-         source.ts meta.class.ts meta.field.declaration.ts
+         source.ts meta.class.ts
           ^^^^^
           source.ts meta.class.ts meta.field.declaration.ts variable.object.property.ts
                ^

--- a/tests/baselines/pr48_noSemiColon.baseline.txt
+++ b/tests/baselines/pr48_noSemiColon.baseline.txt
@@ -152,17 +152,17 @@ Grammar: TypeScript.tmLanguage
                    ^
                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                    source.ts meta.var.expr.ts keyword.operator.assignment.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                     source.ts meta.var.expr.ts
                       ^^^^^^^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                      source.ts meta.var.expr.ts entity.name.function.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                             source.ts meta.var.expr.ts meta.brace.round.ts
                               ^^^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.readwrite.ts
+                              source.ts meta.var.expr.ts variable.other.readwrite.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                 source.ts meta.var.expr.ts meta.brace.round.ts
 >
  ^
  source.ts
@@ -296,39 +296,39 @@ Grammar: TypeScript.tmLanguage
                       ^
                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                       source.ts meta.var.expr.ts keyword.operator.assignment.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                        source.ts meta.var.expr.ts
                          ^^^^^^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                         source.ts meta.var.expr.ts entity.name.function.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                                source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                                  ^^^^^^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                 source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
+                                       source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts
+                                        source.ts meta.var.expr.ts meta.type.parameters.ts
                                          ^^^^^^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                         source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
+                                               source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
                                                 ^
-                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts
+                                                source.ts meta.var.expr.ts meta.type.parameters.ts
                                                  ^^^^^^
-                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                                 source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                                        ^
-                                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                                       source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                                                         ^
-                                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                        source.ts meta.var.expr.ts meta.brace.round.ts
                                                          ^^
-                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts support.module.node.ts
+                                                         source.ts meta.var.expr.ts support.module.node.ts
                                                            ^
-                                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                                           source.ts meta.var.expr.ts punctuation.accessor.ts
                                                             ^^^^^^^^
-                                                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.property.ts
+                                                            source.ts meta.var.expr.ts variable.other.property.ts
                                                                     ^
-                                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                    source.ts meta.var.expr.ts meta.brace.round.ts
 >export const writeFile = thenify<string, string | Buffer, void>(fs.writeFile)
  ^^^^^^
  source.ts meta.var.expr.ts keyword.control.export.ts
@@ -343,47 +343,47 @@ Grammar: TypeScript.tmLanguage
                        ^
                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+                        source.ts meta.var.expr.ts keyword.operator.assignment.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+                         source.ts meta.var.expr.ts
                           ^^^^^^^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts entity.name.function.ts
+                          source.ts meta.var.expr.ts entity.name.function.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
+                                 source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.begin.ts
                                   ^^^^^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                  source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
+                                        source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts
+                                         source.ts meta.var.expr.ts meta.type.parameters.ts
                                           ^^^^^^
-                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                          source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                                 ^
-                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts
+                                                source.ts meta.var.expr.ts meta.type.parameters.ts
                                                  ^
-                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts keyword.operator.type.ts
+                                                 source.ts meta.var.expr.ts meta.type.parameters.ts keyword.operator.type.ts
                                                   ^
-                                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts
+                                                  source.ts meta.var.expr.ts meta.type.parameters.ts
                                                    ^^^^^^
-                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts entity.name.type.ts
+                                                   source.ts meta.var.expr.ts meta.type.parameters.ts entity.name.type.ts
                                                          ^
-                                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
+                                                         source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.separator.comma.ts
                                                           ^
-                                                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts
+                                                          source.ts meta.var.expr.ts meta.type.parameters.ts
                                                            ^^^^
-                                                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts
+                                                           source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts
                                                                ^
-                                                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
+                                                               source.ts meta.var.expr.ts meta.type.parameters.ts punctuation.definition.typeparameters.end.ts
                                                                 ^
-                                                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                source.ts meta.var.expr.ts meta.brace.round.ts
                                                                  ^^
-                                                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts support.module.node.ts
+                                                                 source.ts meta.var.expr.ts support.module.node.ts
                                                                    ^
-                                                                   source.ts meta.var.expr.ts meta.var-single-variable.expr.ts punctuation.accessor.ts
+                                                                   source.ts meta.var.expr.ts punctuation.accessor.ts
                                                                     ^^^^^^^^^
-                                                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts variable.other.property.ts
+                                                                    source.ts meta.var.expr.ts variable.other.property.ts
                                                                              ^
-                                                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.brace.round.ts
+                                                                             source.ts meta.var.expr.ts meta.brace.round.ts
 >
  ^
  source.ts

--- a/tests/baselines/pr48_noSemiColon.txt
+++ b/tests/baselines/pr48_noSemiColon.txt
@@ -80,13 +80,13 @@ Grammar: TypeScript.tmLanguage
         ^^^^^
         [18, 8]: source.ts meta.var.expr.ts storage.type.ts 
                                  ^^^^^^
-                                 [18, 33]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                                 [18, 33]: source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts 
 >export const writeFile = thenify<string, string | Buffer, void>(fs.writeFile)
  ^^^^^^
  [19, 1]: source.ts meta.var.expr.ts keyword.control.export.ts 
         ^^^^^
         [19, 8]: source.ts meta.var.expr.ts storage.type.ts 
                                   ^^^^^^
-                                  [19, 34]: source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.parameters.ts support.type.primitive.ts 
+                                  [19, 34]: source.ts meta.var.expr.ts meta.type.parameters.ts support.type.primitive.ts 
 >
 >

--- a/tests/baselines/readonly.baseline.txt
+++ b/tests/baselines/readonly.baseline.txt
@@ -168,7 +168,7 @@ Grammar: TypeScript.tmLanguage
                             ^
                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts punctuation.separator.comma.ts
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts
                               ^
                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                ^
@@ -205,7 +205,7 @@ Grammar: TypeScript.tmLanguage
                     ^
                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.brace.square.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.indexer.parameter.ts variable.parameter.ts
+                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts variable.parameter.ts
                       ^
                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.type.annotation.ts meta.object.type.ts meta.indexer.declaration.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
                        ^

--- a/tests/baselines/regexp.baseline.txt
+++ b/tests/baselines/regexp.baseline.txt
@@ -16,45 +16,45 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts
+        source.ts meta.var.expr.ts string.regex.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts punctuation.definition.string.begin.ts
+         source.ts meta.var.expr.ts string.regex.ts punctuation.definition.string.begin.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
+          source.ts meta.var.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
            ^^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp punctuation.definition.group.capture.regexp
+           source.ts meta.var.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp punctuation.definition.group.capture.regexp
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp punctuation.definition.group.regexp
+             source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp punctuation.definition.group.regexp
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
+              source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
                ^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp constant.other.character-class.range.regexp
+               source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp constant.other.character-class.range.regexp
                   ^^^
-                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp constant.other.character-class.range.regexp
+                  source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp constant.other.character-class.range.regexp
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp
+                     source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
+                       source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
+                        source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
                          ^^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp constant.other.character-class.regexp
+                         source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp constant.other.character-class.regexp
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp
+                           source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp
                             ^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
+                            source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp constant.other.character-class.set.regexp punctuation.definition.character-class.regexp
                              ^
-                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp meta.group.regexp punctuation.definition.group.regexp
+                             source.ts meta.var.expr.ts string.regex.ts meta.group.regexp meta.group.regexp punctuation.definition.group.regexp
                               ^
-                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp keyword.operator.quantifier.regexp
+                              source.ts meta.var.expr.ts string.regex.ts meta.group.regexp keyword.operator.quantifier.regexp
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
+                               source.ts meta.var.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts punctuation.definition.string.end.ts
+                                source.ts meta.var.expr.ts string.regex.ts punctuation.definition.string.end.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts keyword.other.ts
+                                 source.ts meta.var.expr.ts string.regex.ts keyword.other.ts
                                   ^
                                   source.ts punctuation.terminator.statement.ts
                                    ^^
@@ -69,36 +69,36 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts
+        source.ts meta.var.expr.ts string.regex.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts punctuation.definition.string.begin.ts
+         source.ts meta.var.expr.ts string.regex.ts punctuation.definition.string.begin.ts
           ^^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts constant.other.character-class.regexp
+          source.ts meta.var.expr.ts string.regex.ts constant.other.character-class.regexp
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts keyword.operator.quantifier.regexp
+            source.ts meta.var.expr.ts string.regex.ts keyword.operator.quantifier.regexp
              ^^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts keyword.control.anchor.regexp
+             source.ts meta.var.expr.ts string.regex.ts keyword.control.anchor.regexp
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
+               source.ts meta.var.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
                 ^^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp
+                source.ts meta.var.expr.ts string.regex.ts meta.group.regexp
                      ^^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp constant.other.character-class.regexp
+                     source.ts meta.var.expr.ts string.regex.ts meta.group.regexp constant.other.character-class.regexp
                        ^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp keyword.operator.quantifier.regexp
+                       source.ts meta.var.expr.ts string.regex.ts meta.group.regexp keyword.operator.quantifier.regexp
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
+                        source.ts meta.var.expr.ts string.regex.ts meta.group.regexp punctuation.definition.group.regexp
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts keyword.operator.quantifier.regexp
+                         source.ts meta.var.expr.ts string.regex.ts keyword.operator.quantifier.regexp
                           ^^^^^^^^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts
+                          source.ts meta.var.expr.ts string.regex.ts
                                   ^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts keyword.control.anchor.regexp
+                                  source.ts meta.var.expr.ts string.regex.ts keyword.control.anchor.regexp
                                     ^
-                                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts punctuation.definition.string.end.ts
+                                    source.ts meta.var.expr.ts string.regex.ts punctuation.definition.string.end.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts string.regex.ts keyword.other.ts
+                                     source.ts meta.var.expr.ts string.regex.ts keyword.other.ts
                                       ^
                                       source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/restAndSpreadExpression.baseline.txt
+++ b/tests/baselines/restAndSpreadExpression.baseline.txt
@@ -418,7 +418,7 @@ Grammar: TypeScript.tmLanguage
                                ^
                                source.ts meta.function.ts meta.return.type.ts meta.object.type.ts punctuation.definition.block.ts
                                 ^
-                                source.ts meta.function.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts
+                                source.ts meta.function.ts meta.return.type.ts meta.object.type.ts
                                  ^^
                                  source.ts meta.function.ts meta.return.type.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                    ^

--- a/tests/baselines/restAndSpreadExpression.baseline.txt
+++ b/tests/baselines/restAndSpreadExpression.baseline.txt
@@ -84,61 +84,61 @@ Grammar: TypeScript.tmLanguage
                    ^
                    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
                     ^
-                    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+                    source.ts meta.var.expr.ts keyword.operator.assignment.ts
                      ^
-                     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+                     source.ts meta.var.expr.ts
                       ^
-                      source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts punctuation.definition.block.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                        ^
-                       source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts
+                       source.ts meta.var.expr.ts meta.object-literal.ts
                         ^
-                        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                        source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                          ^
-                         source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                         source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                           ^
-                          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts
+                          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                            ^
-                           source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
+                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
                             ^
-                            source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts punctuation.separator.comma.ts
+                            source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                              ^
-                             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts
+                             source.ts meta.var.expr.ts meta.object-literal.ts
                               ^
-                              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                              source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                                ^
-                               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                               source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts
+                                source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
+                                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                  source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts
+                                   source.ts meta.var.expr.ts meta.object-literal.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts
+                                      source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
+                                       source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts punctuation.separator.comma.ts
+                                        source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                                          ^
-                                         source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts
+                                         source.ts meta.var.expr.ts meta.object-literal.ts
                                           ^
-                                          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
+                                          source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts
                                            ^
-                                           source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
+                                           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts meta.object-literal.key.ts punctuation.separator.key-value.ts
                                             ^
-                                            source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts
+                                            source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
+                                             source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts constant.numeric.decimal.ts
                                               ^
-                                              source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts meta.object.member.ts
+                                              source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.object-literal.ts punctuation.definition.block.ts
+                                               source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                                                 ^
                                                 source.ts punctuation.terminator.statement.ts
                                                  ^^
@@ -244,11 +244,11 @@ Grammar: TypeScript.tmLanguage
                        ^
                        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
                         ^
-                        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+                        source.ts meta.var.expr.ts keyword.operator.assignment.ts
                          ^
-                         source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+                         source.ts meta.var.expr.ts
                           ^
-                          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts variable.other.readwrite.ts
+                          source.ts meta.var.expr.ts variable.other.readwrite.ts
                            ^
                            source.ts punctuation.terminator.statement.ts
                             ^^
@@ -285,39 +285,39 @@ Grammar: TypeScript.tmLanguage
                      ^
                      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
                       ^
-                      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+                      source.ts meta.var.expr.ts keyword.operator.assignment.ts
                        ^
-                       source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+                       source.ts meta.var.expr.ts
                         ^
-                        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts meta.brace.square.ts
+                        source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                          ^
-                         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                         source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                           ^
-                          source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts
+                          source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                            ^
-                           source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                           source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                             ^
-                            source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts punctuation.separator.comma.ts
+                            source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                              ^
-                             source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts
+                             source.ts meta.var.expr.ts meta.array.literal.ts
                               ^
-                              source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                              source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                ^
-                               source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts
+                               source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts punctuation.separator.comma.ts
+                                 source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts
+                                  source.ts meta.var.expr.ts meta.array.literal.ts
                                    ^
-                                   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                   source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                     ^
-                                    source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts
+                                    source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.array.literal.ts meta.brace.square.ts
+                                      source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                                        ^
                                        source.ts punctuation.terminator.statement.ts
                                         ^^
@@ -337,33 +337,33 @@ Grammar: TypeScript.tmLanguage
       ^
       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
        ^
-       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
         ^
-        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+        source.ts meta.var.expr.ts
          ^
-         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+         source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+          source.ts meta.var.expr.ts meta.object-literal.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+           source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+            source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+             source.ts meta.var.expr.ts meta.object-literal.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+              source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
+               source.ts meta.var.expr.ts meta.object-literal.ts punctuation.separator.comma.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts
+                source.ts meta.var.expr.ts meta.object-literal.ts
                  ^^^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts keyword.operator.spread.ts
+                 source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts keyword.operator.spread.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
+                    source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts variable.other.readwrite.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts meta.object.member.ts
+                     source.ts meta.var.expr.ts meta.object-literal.ts meta.object.member.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.object-literal.ts punctuation.definition.block.ts
+                      source.ts meta.var.expr.ts meta.object-literal.ts punctuation.definition.block.ts
                        ^
                        source.ts punctuation.terminator.statement.ts
                         ^^
@@ -562,21 +562,21 @@ Grammar: TypeScript.tmLanguage
          ^
          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
           ^
-          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+          source.ts meta.var.expr.ts keyword.operator.assignment.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+           source.ts meta.var.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+            source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts constant.numeric.decimal.ts
+             source.ts meta.var.expr.ts meta.array.literal.ts constant.numeric.decimal.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
+              source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+               source.ts meta.var.expr.ts meta.array.literal.ts
                 ^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts constant.numeric.decimal.ts
+                source.ts meta.var.expr.ts meta.array.literal.ts constant.numeric.decimal.ts
                  ^
-                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                 source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                   ^
                   source.ts punctuation.terminator.statement.ts
                    ^^
@@ -632,29 +632,29 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
            ^
-           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+           source.ts meta.var.expr.ts keyword.operator.assignment.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+            source.ts meta.var.expr.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+             source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+              source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                ^^^^^^^^^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts
+               source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                         ^
-                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                        source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                          ^
-                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
+                         source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                           ^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+                          source.ts meta.var.expr.ts meta.array.literal.ts
                            ^
-                           source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                           source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                             ^^^^^
-                            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts
+                            source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                 source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                   ^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                                  source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                                    ^
                                    source.ts punctuation.terminator.statement.ts
                                     ^^
@@ -669,46 +669,46 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
             ^
-            source.ts meta.var.expr.ts meta.var-single-variable.expr.ts keyword.operator.assignment.ts
+            source.ts meta.var.expr.ts keyword.operator.assignment.ts
              ^
-             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+             source.ts meta.var.expr.ts
               ^
-              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+              source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                ^
-               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+               source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                 ^^^^
-                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts
+                source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                     ^
-                    source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                    source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                      ^
-                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
+                     source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                       ^
-                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+                      source.ts meta.var.expr.ts meta.array.literal.ts
                        ^^^
-                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts keyword.operator.spread.ts
+                       source.ts meta.var.expr.ts meta.array.literal.ts keyword.operator.spread.ts
                           ^^^^^
-                          source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts variable.other.readwrite.ts
+                          source.ts meta.var.expr.ts meta.array.literal.ts variable.other.readwrite.ts
                                ^
-                               source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
+                               source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                                 ^
-                                source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+                                source.ts meta.var.expr.ts meta.array.literal.ts
                                  ^
-                                 source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                 source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                   ^^^
-                                  source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts
+                                  source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                                      ^
-                                     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                     source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                       ^
-                                      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
+                                      source.ts meta.var.expr.ts meta.array.literal.ts punctuation.separator.comma.ts
                                        ^
-                                       source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts
+                                       source.ts meta.var.expr.ts meta.array.literal.ts
                                         ^
-                                        source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
+                                        source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                          ^^^^
-                                         source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts
+                                         source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts
                                              ^
-                                             source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
+                                             source.ts meta.var.expr.ts meta.array.literal.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                               ^
-                                              source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.array.literal.ts meta.brace.square.ts
+                                              source.ts meta.var.expr.ts meta.array.literal.ts meta.brace.square.ts
                                                ^
                                                source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/variableBindingPattern.baseline.txt
+++ b/tests/baselines/variableBindingPattern.baseline.txt
@@ -203,7 +203,7 @@ Grammar: TypeScript.tmLanguage
                       ^
                       source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts punctuation.definition.block.ts
                        ^
-                       source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+                       source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts
                         ^^^^^
                         source.ts meta.function.ts meta.block.ts meta.object-literal.ts meta.object.member.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                              ^
@@ -453,7 +453,7 @@ Grammar: TypeScript.tmLanguage
                                                  source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts
 >    x: {
  ^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts
      ^
      source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
       ^
@@ -466,7 +466,7 @@ Grammar: TypeScript.tmLanguage
          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        a: number;
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -481,7 +481,7 @@ Grammar: TypeScript.tmLanguage
                    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        b: number;
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -505,7 +505,7 @@ Grammar: TypeScript.tmLanguage
        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts
 >    y: {
  ^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts
      ^
      source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
       ^
@@ -518,7 +518,7 @@ Grammar: TypeScript.tmLanguage
          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        c: string;
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -533,7 +533,7 @@ Grammar: TypeScript.tmLanguage
                    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
 >        d: string;
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts
          ^
          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
           ^
@@ -557,7 +557,7 @@ Grammar: TypeScript.tmLanguage
        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts
 >    z: [number, {
  ^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts
      ^
      source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
       ^
@@ -578,7 +578,7 @@ Grammar: TypeScript.tmLanguage
                   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts
 >        hello: string;
  ^^^^^^^^
- source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+ source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts
          ^^^^^
          source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts meta.object.type.ts meta.field.declaration.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
               ^
@@ -655,7 +655,7 @@ Grammar: TypeScript.tmLanguage
               ^
               source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts punctuation.definition.block.ts
                ^
-               source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+               source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts
                 ^^^^^
                 source.ts meta.function.ts meta.block.ts cast.expr.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                      ^
@@ -789,7 +789,7 @@ Grammar: TypeScript.tmLanguage
                         ^
                         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts punctuation.definition.block.ts
                          ^
-                         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts
+                         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts
                           ^^^^^
                           source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.type.annotation.ts meta.type.tuple.ts meta.object.type.ts meta.field.declaration.ts variable.object.property.ts
                                ^

--- a/tests/baselines/variableBindingPattern.baseline.txt
+++ b/tests/baselines/variableBindingPattern.baseline.txt
@@ -351,15 +351,15 @@ Grammar: TypeScript.tmLanguage
                                               ^
                                               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
                                                ^
-                                               source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+                                               source.ts meta.var.expr.ts keyword.operator.assignment.ts
                                                 ^
-                                                source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+                                                source.ts meta.var.expr.ts
                                                  ^^^
-                                                 source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts entity.name.function.ts
+                                                 source.ts meta.var.expr.ts entity.name.function.ts
                                                     ^
-                                                    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.brace.round.ts
+                                                    source.ts meta.var.expr.ts meta.brace.round.ts
                                                      ^
-                                                     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.brace.round.ts
+                                                     source.ts meta.var.expr.ts meta.brace.round.ts
                                                       ^
                                                       source.ts punctuation.terminator.statement.ts
                                                        ^^
@@ -608,15 +608,15 @@ Grammar: TypeScript.tmLanguage
   ^
   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.type.annotation.ts
    ^
-   source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts keyword.operator.assignment.ts
+   source.ts meta.var.expr.ts keyword.operator.assignment.ts
     ^
-    source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts
+    source.ts meta.var.expr.ts
      ^^^
-     source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts entity.name.function.ts
+     source.ts meta.var.expr.ts entity.name.function.ts
         ^
-        source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.brace.round.ts
+        source.ts meta.var.expr.ts meta.brace.round.ts
          ^
-         source.ts meta.var.expr.ts meta.object-binding-pattern-variable.ts meta.brace.round.ts
+         source.ts meta.var.expr.ts meta.brace.round.ts
           ^
           source.ts punctuation.terminator.statement.ts
            ^^
@@ -746,15 +746,15 @@ Grammar: TypeScript.tmLanguage
                      ^
                      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
                       ^
-                      source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+                      source.ts meta.var.expr.ts keyword.operator.assignment.ts
                        ^
-                       source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+                       source.ts meta.var.expr.ts
                         ^^^
-                        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts entity.name.function.ts
+                        source.ts meta.var.expr.ts entity.name.function.ts
                            ^
-                           source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                           source.ts meta.var.expr.ts meta.brace.round.ts
                             ^
-                            source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                            source.ts meta.var.expr.ts meta.brace.round.ts
                              ^
                              source.ts punctuation.terminator.statement.ts
                               ^^
@@ -813,14 +813,14 @@ Grammar: TypeScript.tmLanguage
                                                   ^
                                                   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.type.annotation.ts
                                                    ^
-                                                   source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts keyword.operator.assignment.ts
+                                                   source.ts meta.var.expr.ts keyword.operator.assignment.ts
                                                     ^
-                                                    source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts
+                                                    source.ts meta.var.expr.ts
                                                      ^^^
-                                                     source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts entity.name.function.ts
+                                                     source.ts meta.var.expr.ts entity.name.function.ts
                                                         ^
-                                                        source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                                                        source.ts meta.var.expr.ts meta.brace.round.ts
                                                          ^
-                                                         source.ts meta.var.expr.ts meta.array-binding-pattern-variable.ts meta.brace.round.ts
+                                                         source.ts meta.var.expr.ts meta.brace.round.ts
                                                           ^
                                                           source.ts punctuation.terminator.statement.ts

--- a/tests/cases/Issue304.ts
+++ b/tests/cases/Issue304.ts
@@ -1,0 +1,9 @@
+export const EditorPanel = connect(
+    (state: Immutable<AppState>): Object => ( {
+        edditorState: (state.editors[state.activeTab]),
+        macroSettingsOpen: state.macroSettingsOpen,
+    }),
+    (dispatch: Dispatch): Object => ({
+        onchange(next: EditorSDtate): void { dispatch(actions) }
+    })
+)

--- a/tests/cases/Issue305.ts
+++ b/tests/cases/Issue305.ts
@@ -1,0 +1,4 @@
+abstract class Base {
+    protected abstract topic: string
+    constructor(protected wire: Transport, protected token?: string, readonly bar?: boolean) { }
+}

--- a/tests/cases/Issue307.ts
+++ b/tests/cases/Issue307.ts
@@ -1,0 +1,9 @@
+class Test {
+  method() {
+    const obj = { a: 'hello' };
+    const {
+      a
+    } = obj;
+    const x = 'world';
+  }
+}

--- a/tests/cases/destructuringWithDefaults.ts
+++ b/tests/cases/destructuringWithDefaults.ts
@@ -1,0 +1,28 @@
+interface IOptions {
+    check: boolean;
+    files: string;
+    primary: string;
+}
+var {
+    check: isReportMode = false,
+    files = '**/locals/*.json',
+    primary: primaryLanguage = 'en'
+}: IOptions = null;
+function sync({
+    check: isReportMode = false,
+    files = '**/locals/*.json',
+    primary: primaryLanguage = 'en'
+}: IOptions) {
+}
+
+var [
+    check2 = false,
+    files2 = '**/locals/*.json',
+    primary2 = 'en'
+] = [];
+function sync2([
+    check2 = false,
+    files2 = '**/locals/*.json',
+    primary2 = 'en'
+]) {
+}


### PR DESCRIPTION
- Allow Class. in jsdoc handles #300 partially
- Support default initializers in destructuring, Fixes #302 
- Fix modifier detection in fields and parameters. Fixes #305 and #306 
- Update arrow detection. Fixes #304 
- Update variable and destructuring pattern. Fixes #307
- Remove all usages of \G from grammar to make sure Sublime and vscode don't differ in experience. Fixes #312 