### PR TITLE
Difference between function's Usage and Definition

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -641,7 +641,7 @@ repository:
       '2': { name: storage.modifier.async.ts }
       '3': { name: storage.type.function.ts }
       '4': { name: keyword.generator.asterisk.ts }
-      '5': { name: meta.definition.function.ts entity.name.function.ts }
+      '5': { name: meta.definition.function.ts entity.name.definition.function.ts }
     end: (?=;|\})|(?<=\})
     patterns:
     - include: '#comment'


### PR DESCRIPTION
When you're authoring a theme one thing with the new grammar really bothers and that's the fact that there is no difference between function's color when you're using a function and for when you're declaring a function:

<img width="540" alt="screen shot 2016-11-18 at 1 26 53 am" src="https://cloud.githubusercontent.com/assets/2157285/20409420/bebb501c-ad2e-11e6-9720-765a2cfa3883.png">

I want my functions to be black but when I'm declaring them, they be red. I can because definition and usage have both exactly the same token names (`function.block.name.entity.meta.ts` to be exact)

<img width="1138" alt="screen shot 2016-11-18 at 1 27 57 am" src="https://cloud.githubusercontent.com/assets/2157285/20409466/f2b9a3a0-ad2e-11e6-9f6a-5879253a1f1d.png">

<img width="831" alt="screen shot 2016-11-18 at 1 28 19 am" src="https://cloud.githubusercontent.com/assets/2157285/20409467/f2ca8828-ad2e-11e6-87f1-1db79a5a7d0e.png">

My change is a very very simple one. I have added one more token name `definition` to the token for the function's definition so that one can choose only the definition or the usage and this change won't break any existing grammar as it's an incremental change to the previous version.
