### PR TITLE
Generate new UUIDs

### DIFF
--- a/Comments.tmPreferences
+++ b/Comments.tmPreferences
@@ -31,6 +31,6 @@
 		</array>
 	</dict>
 	<key>uuid</key>
-	<string>A67A8BD9-A951-406F-9175-018DD4B52FD1</string>
+	<string>FF9A09B1-D1C3-4AF0-9A11-2EC300F03184</string>
 </dict>
 </plist>

--- a/TypeScript.YAML-tmTheme
+++ b/TypeScript.YAML-tmTheme
@@ -2,7 +2,7 @@
 
 ---
 name: TypeScript
-uuid: ef98eb90-bf9b-11e4-bb52-0800200c9a66
+uuid: 91489F9C-F403-4CF0-993D-EAAF9149E40E
 
 settings:
 - scope: storage.modifier, storage.type, keyword.control, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression

--- a/TypeScript.tmTheme
+++ b/TypeScript.tmTheme
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>TypeScript</string>
     <key>uuid</key>
-    <string>ef98eb90-bf9b-11e4-bb52-0800200c9a66</string>
+    <string>91489F9C-F403-4CF0-993D-EAAF9149E40E</string>
     <key>settings</key>
     <array>
       <dict>

--- a/TypeScriptReact.YAML-tmTheme
+++ b/TypeScriptReact.YAML-tmTheme
@@ -3,7 +3,7 @@
 
 ---
 name: TypeScriptReact
-uuid: ef98eb90-bf9b-11e4-bb52-0800200c9a66
+uuid: 8B704EF9-AF8E-402F-933C-1D46D8C49E58
 
 settings:
 # Additions

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -5,7 +5,7 @@
     <key>name</key>
     <string>TypeScriptReact</string>
     <key>uuid</key>
-    <string>ef98eb90-bf9b-11e4-bb52-0800200c9a66</string>
+    <string>8B704EF9-AF8E-402F-933C-1D46D8C49E58</string>
     <key>settings</key>
     <array>
       <dict>


### PR DESCRIPTION
TextMate and other similar editors require the UUID value to be globally unique, I am not aware of VSCode's usage of UUIDs. For the Comments file the UUID was shared with the similar preference item from the JavaScript bundle causing a conflict. For the theme files the UUID conflict was with the language grammar files in this bundle.