### PR TITLE
Mark TSX Class Tags Differently from Normal Html Elements

### DIFF
--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -94,18 +94,18 @@ repository:
 
   jsx-tag-without-attributes:
     name: meta.tag.without-attributes.tsx
-    begin: (<)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>)
-    end: (</)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>)
+    begin: (<)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>)
+    end: (</)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>)
     beginCaptures:
       '1': {name: punctuation.definition.tag.begin.tsx}
       '2': {name: entity.name.tag.tsx}
-      '4': {name: support.class.component.tsx}
-      '5': {name: punctuation.definition.tag.end.tsx}
+      '3': {name: support.class.component.tsx}
+      '4': {name: punctuation.definition.tag.end.tsx}
     endCaptures:
       '1': {name: punctuation.definition.tag.begin.tsx}
       '2': {name: entity.name.tag.tsx}
-      '4': {name: support.class.component.tsx}
-      '5': {name: punctuation.definition.tag.end.tsx}
+      '3': {name: support.class.component.tsx}
+      '4': {name: punctuation.definition.tag.end.tsx}
     contentName: meta.jsx.children.tsx
     patterns:
     - include: '#jsx-children'
@@ -120,14 +120,14 @@ repository:
         (?=(<)\s*
         ([_$a-zA-Z][-$\w.]*(?<!\.|-))
         (?=\s+(?!\?)|/?>))
-    end: (/>)|(?:(</)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>))
+    end: (/>)|(?:(</)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>))
     endCaptures:
       '0': { name: meta.tag.tsx }
       '1': { name: punctuation.definition.tag.end.tsx }
       '2': { name: punctuation.definition.tag.begin.tsx }
       '3': { name: entity.name.tag.tsx }
-      '5': { name: support.class.component.tsx }
-      '6': { name: punctuation.definition.tag.end.tsx }
+      '4': { name: support.class.component.tsx }
+      '5': { name: punctuation.definition.tag.end.tsx }
     patterns:
     - include: '#jsx-tag'
 
@@ -138,14 +138,14 @@ repository:
         (?=(<)\s*
         ([_$a-zA-Z][-$\w.]*(?<!\.|-))
         (?=\s+(?!\?)|/?>))
-    end: (/>)|(?:(</)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>))
+    end: (/>)|(?:(</)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>))
     endCaptures:
       '0': { name: meta.tag.tsx }
       '1': { name: punctuation.definition.tag.end.tsx }
       '2': { name: punctuation.definition.tag.begin.tsx }
       '3': { name: entity.name.tag.tsx }
-      '5': { name: support.class.component.tsx }
-      '6': { name: punctuation.definition.tag.end.tsx }
+      '4': { name: support.class.component.tsx }
+      '5': { name: punctuation.definition.tag.end.tsx }
     patterns:
     - include: '#jsx-tag'
 
@@ -161,12 +161,12 @@ repository:
     - begin: |-
         (?x)
           (<)\s*
-          (([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))
+          ((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))
           (?=\s+(?!\?)|/?>)
       beginCaptures:
         '1': { name: punctuation.definition.tag.begin.tsx }
         '2': { name: entity.name.tag.tsx }
-        '4': { name: support.class.component.tsx }
+        '3': { name: support.class.component.tsx }
       end: (?=[/]?>)
       patterns:
       - include: '#comment'

--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -94,16 +94,18 @@ repository:
 
   jsx-tag-without-attributes:
     name: meta.tag.without-attributes.tsx
-    begin: (<)\s*([_$a-zA-Z][-$\w.]*(?<!\.|-))\s*(>)
-    end: (</)\s*([_$a-zA-Z][-$\w.]*(?<!\.|-))\s*(>)
+    begin: (<)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>)
+    end: (</)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>)
     beginCaptures:
       '1': {name: punctuation.definition.tag.begin.tsx}
       '2': {name: entity.name.tag.tsx}
-      '3': {name: punctuation.definition.tag.end.tsx}
+      '4': {name: support.class.component.tsx}
+      '5': {name: punctuation.definition.tag.end.tsx}
     endCaptures:
       '1': {name: punctuation.definition.tag.begin.tsx}
       '2': {name: entity.name.tag.tsx}
-      '3': {name: punctuation.definition.tag.end.tsx}
+      '4': {name: support.class.component.tsx}
+      '5': {name: punctuation.definition.tag.end.tsx}
     contentName: meta.jsx.children.tsx
     patterns:
     - include: '#jsx-children'
@@ -118,13 +120,14 @@ repository:
         (?=(<)\s*
         ([_$a-zA-Z][-$\w.]*(?<!\.|-))
         (?=\s+(?!\?)|/?>))
-    end: (/>)|(?:(</)\s*([_$a-zA-Z][-$\w.]*(?<!\.|-))\s*(>))
+    end: (/>)|(?:(</)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>))
     endCaptures:
       '0': { name: meta.tag.tsx }
       '1': { name: punctuation.definition.tag.end.tsx }
       '2': { name: punctuation.definition.tag.begin.tsx }
       '3': { name: entity.name.tag.tsx }
-      '4': { name: punctuation.definition.tag.end.tsx }
+      '5': { name: support.class.component.tsx }
+      '6': { name: punctuation.definition.tag.end.tsx }
     patterns:
     - include: '#jsx-tag'
 
@@ -135,13 +138,14 @@ repository:
         (?=(<)\s*
         ([_$a-zA-Z][-$\w.]*(?<!\.|-))
         (?=\s+(?!\?)|/?>))
-    end: (/>)|(?:(</)\s*([_$a-zA-Z][-$\w.]*(?<!\.|-))\s*(>))
+    end: (/>)|(?:(</)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))\s*(>))
     endCaptures:
       '0': { name: meta.tag.tsx }
       '1': { name: punctuation.definition.tag.end.tsx }
       '2': { name: punctuation.definition.tag.begin.tsx }
       '3': { name: entity.name.tag.tsx }
-      '4': { name: punctuation.definition.tag.end.tsx }
+      '5': { name: support.class.component.tsx }
+      '6': { name: punctuation.definition.tag.end.tsx }
     patterns:
     - include: '#jsx-tag'
 
@@ -157,11 +161,12 @@ repository:
     - begin: |-
         (?x)
           (<)\s*
-          ([_$a-zA-Z][-$\w.]*(?<!\.|-))
+          (([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?<!\.|-))
           (?=\s+(?!\?)|/?>)
       beginCaptures:
         '1': { name: punctuation.definition.tag.begin.tsx }
         '2': { name: entity.name.tag.tsx }
+        '4': { name: support.class.component.tsx }
       end: (?=[/]?>)
       patterns:
       - include: '#comment'

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -6527,9 +6527,9 @@
         <key>name</key>
         <string>meta.tag.without-attributes.tsx</string>
         <key>begin</key>
-        <string>(&lt;)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;)</string>
+        <string>(&lt;)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;)</string>
         <key>end</key>
-        <string>(&lt;/)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;)</string>
+        <string>(&lt;/)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;)</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -6542,12 +6542,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>4</key>
+          <key>3</key>
           <dict>
             <key>name</key>
             <string>support.class.component.tsx</string>
           </dict>
-          <key>5</key>
+          <key>4</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6565,12 +6565,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>4</key>
+          <key>3</key>
           <dict>
             <key>name</key>
             <string>support.class.component.tsx</string>
           </dict>
-          <key>5</key>
+          <key>4</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6594,10 +6594,10 @@
   (?!(&lt;)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;)) #look ahead is not start of tag without attributes
   (?!&lt;\s*[_$[:alpha:]][_$[:alnum:]]*((\s+extends\s+[^=&gt;])|,)) # look ahead is not type parameter of arrow
   (?=(&lt;)\s*
-  ([_$a-zA-Z][-$\w.]*)(?&lt;!\.|-)
+  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
   (?=\s+(?!\?)|/?&gt;))</string>
         <key>end</key>
-        <string>(/&gt;)|(?:(&lt;/)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;))</string>
+        <string>(/&gt;)|(?:(&lt;/)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;))</string>
         <key>endCaptures</key>
         <dict>
           <key>0</key>
@@ -6620,12 +6620,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>5</key>
+          <key>4</key>
           <dict>
             <key>name</key>
             <string>support.class.component.tsx</string>
           </dict>
-          <key>6</key>
+          <key>5</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6644,10 +6644,10 @@
         <key>begin</key>
         <string>(?x)
   (?=(&lt;)\s*
-  ([_$a-zA-Z][-$\w.]*)(?&lt;!\.|-)
+  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
   (?=\s+(?!\?)|/?&gt;))</string>
         <key>end</key>
-        <string>(/&gt;)|(?:(&lt;/)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;))</string>
+        <string>(/&gt;)|(?:(&lt;/)\s*((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;))</string>
         <key>endCaptures</key>
         <dict>
           <key>0</key>
@@ -6670,12 +6670,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>5</key>
+          <key>4</key>
           <dict>
             <key>name</key>
             <string>support.class.component.tsx</string>
           </dict>
-          <key>6</key>
+          <key>5</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6706,7 +6706,7 @@
             <key>begin</key>
             <string>(?x)
   (&lt;)\s*
-  (([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))
+  ((?:[a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))
   (?=\s+(?!\?)|/?&gt;)</string>
             <key>beginCaptures</key>
             <dict>
@@ -6720,7 +6720,7 @@
                 <key>name</key>
                 <string>entity.name.tag.tsx</string>
               </dict>
-              <key>4</key>
+              <key>3</key>
               <dict>
                 <key>name</key>
                 <string>support.class.component.tsx</string>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -6527,9 +6527,9 @@
         <key>name</key>
         <string>meta.tag.without-attributes.tsx</string>
         <key>begin</key>
-        <string>(&lt;)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;)</string>
+        <string>(&lt;)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;)</string>
         <key>end</key>
-        <string>(&lt;/)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;)</string>
+        <string>(&lt;/)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;)</string>
         <key>beginCaptures</key>
         <dict>
           <key>1</key>
@@ -6542,7 +6542,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>3</key>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>support.class.component.tsx</string>
+          </dict>
+          <key>5</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6560,7 +6565,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>3</key>
+          <key>4</key>
+          <dict>
+            <key>name</key>
+            <string>support.class.component.tsx</string>
+          </dict>
+          <key>5</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6584,10 +6594,10 @@
   (?!(&lt;)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;)) #look ahead is not start of tag without attributes
   (?!&lt;\s*[_$[:alpha:]][_$[:alnum:]]*((\s+extends\s+[^=&gt;])|,)) # look ahead is not type parameter of arrow
   (?=(&lt;)\s*
-  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
+  ([_$a-zA-Z][-$\w.]*)(?&lt;!\.|-)
   (?=\s+(?!\?)|/?&gt;))</string>
         <key>end</key>
-        <string>(/&gt;)|(?:(&lt;/)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;))</string>
+        <string>(/&gt;)|(?:(&lt;/)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;))</string>
         <key>endCaptures</key>
         <dict>
           <key>0</key>
@@ -6610,7 +6620,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>4</key>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>support.class.component.tsx</string>
+          </dict>
+          <key>6</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6629,10 +6644,10 @@
         <key>begin</key>
         <string>(?x)
   (?=(&lt;)\s*
-  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
+  ([_$a-zA-Z][-$\w.]*)(?&lt;!\.|-)
   (?=\s+(?!\?)|/?&gt;))</string>
         <key>end</key>
-        <string>(/&gt;)|(?:(&lt;/)\s*([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))\s*(&gt;))</string>
+        <string>(/&gt;)|(?:(&lt;/)\s*(([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))\s*(&gt;))</string>
         <key>endCaptures</key>
         <dict>
           <key>0</key>
@@ -6655,7 +6670,12 @@
             <key>name</key>
             <string>entity.name.tag.tsx</string>
           </dict>
-          <key>4</key>
+          <key>5</key>
+          <dict>
+            <key>name</key>
+            <string>support.class.component.tsx</string>
+          </dict>
+          <key>6</key>
           <dict>
             <key>name</key>
             <string>punctuation.definition.tag.end.tsx</string>
@@ -6686,7 +6706,7 @@
             <key>begin</key>
             <string>(?x)
   (&lt;)\s*
-  ([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))
+  (([a-z][a-z0-9]*|([_$a-zA-Z][-$\w.]*))(?&lt;!\.|-))
   (?=\s+(?!\?)|/?&gt;)</string>
             <key>beginCaptures</key>
             <dict>
@@ -6699,6 +6719,11 @@
               <dict>
                 <key>name</key>
                 <string>entity.name.tag.tsx</string>
+              </dict>
+              <key>4</key>
+              <dict>
+                <key>name</key>
+                <string>support.class.component.tsx</string>
               </dict>
             </dict>
             <key>end</key>

--- a/tests/baselines/Issue161.baseline.txt
+++ b/tests/baselines/Issue161.baseline.txt
@@ -93,7 +93,7 @@ Grammar: TypeScriptReact.tmLanguage
           ^
           source.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
            ^^^^^^^
-           source.tsx meta.block.tsx meta.tag.tsx entity.name.tag.tsx
+           source.tsx meta.block.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                   ^^
                   source.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
                     ^

--- a/tests/baselines/Issue264.baseline.txt
+++ b/tests/baselines/Issue264.baseline.txt
@@ -18,7 +18,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^
  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
   ^^^^
-  source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+  source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
       ^
       source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
        ^^
@@ -51,7 +51,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^
  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
    ^^^^
-   source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+   source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
        ^
        source.tsx meta.tag.without-attributes.tsx
         ^

--- a/tests/baselines/Issue415.baseline.txt
+++ b/tests/baselines/Issue415.baseline.txt
@@ -1,0 +1,315 @@
+original file
+-----------------------------------
+(<View />);
+(<dot.view />);
+(<dot.View />);
+(<dot.View />);
+(<View></View>);
+(<dot.View></dot.View>);
+(<dot.View><b>bold</b></dot.View>);
+-----------------------------------
+
+Grammar: TypeScriptReact.tmLanguage
+-----------------------------------
+>(<View />);
+ ^
+ source.tsx meta.brace.round.tsx
+  ^
+  source.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+   ^^^^
+   source.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
+       ^
+       source.tsx meta.tag.tsx
+        ^^
+        source.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+          ^
+          source.tsx meta.brace.round.tsx
+           ^
+           source.tsx punctuation.terminator.statement.tsx
+>(<dot.view />);
+ ^
+ source.tsx meta.brace.round.tsx
+  ^
+  source.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+   ^^^^^^^^
+   source.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
+           ^
+           source.tsx meta.tag.tsx
+            ^^
+            source.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+              ^
+              source.tsx meta.brace.round.tsx
+               ^
+               source.tsx punctuation.terminator.statement.tsx
+>(<dot.View />);
+ ^
+ source.tsx meta.brace.round.tsx
+  ^
+  source.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+   ^^^^^^^^
+   source.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
+           ^
+           source.tsx meta.tag.tsx
+            ^^
+            source.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+              ^
+              source.tsx meta.brace.round.tsx
+               ^
+               source.tsx punctuation.terminator.statement.tsx
+>(<dot.View />);
+ ^
+ source.tsx meta.brace.round.tsx
+  ^
+  source.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
+   ^^^^^^^^
+   source.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
+           ^
+           source.tsx meta.tag.tsx
+            ^^
+            source.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
+              ^
+              source.tsx meta.brace.round.tsx
+               ^
+               source.tsx punctuation.terminator.statement.tsx
+>(<View></View>);
+ ^
+ source.tsx meta.brace.round.tsx
+  ^
+  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+   ^^^^
+   source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
+       ^
+       source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+        ^^
+        source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+          ^^^^
+          source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
+              ^
+              source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+               ^
+               source.tsx meta.brace.round.tsx
+                ^
+                source.tsx punctuation.terminator.statement.tsx
+>(<dot.View></dot.View>);
+ ^
+ source.tsx meta.brace.round.tsx
+  ^
+  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+   ^^^^^^^^
+   source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
+           ^
+           source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+            ^^
+            source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+              ^^^^^^^^
+              source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
+                      ^
+                      source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                       ^
+                       source.tsx meta.brace.round.tsx
+                        ^
+                        source.tsx punctuation.terminator.statement.tsx
+>(<dot.View><b>bold</b></dot.View>);
+ ^
+ source.tsx meta.brace.round.tsx
+  ^
+  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+   ^^^^^^^^
+   source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
+           ^
+           source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+            ^
+            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+             ^
+             source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+              ^
+              source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+               ^^^^
+               source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
+                   ^^
+                   source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                     ^
+                     source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+                      ^
+                      source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                       ^^
+                       source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
+                         ^^^^^^^^
+                         source.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
+                                 ^
+                                 source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
+                                  ^
+                                  source.tsx meta.brace.round.tsx
+                                   ^
+                                   source.tsx punctuation.terminator.statement.tsx
+
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>(<View />);
+ ^
+ source.ts meta.brace.round.ts
+  ^
+  source.ts cast.expr.ts meta.brace.angle.ts
+   ^^^^
+   source.ts cast.expr.ts entity.name.type.ts
+       ^^
+       source.ts cast.expr.ts
+         ^
+         source.ts cast.expr.ts meta.brace.angle.ts
+          ^
+          source.ts meta.brace.round.ts
+           ^
+           source.ts punctuation.terminator.statement.ts
+>(<dot.view />);
+ ^
+ source.ts meta.brace.round.ts
+  ^
+  source.ts cast.expr.ts meta.brace.angle.ts
+   ^^^
+   source.ts cast.expr.ts entity.name.type.module.ts
+      ^
+      source.ts cast.expr.ts punctuation.accessor.ts
+       ^^^^
+       source.ts cast.expr.ts entity.name.type.ts
+           ^^
+           source.ts cast.expr.ts
+             ^
+             source.ts cast.expr.ts meta.brace.angle.ts
+              ^
+              source.ts meta.brace.round.ts
+               ^
+               source.ts punctuation.terminator.statement.ts
+>(<dot.View />);
+ ^
+ source.ts meta.brace.round.ts
+  ^
+  source.ts cast.expr.ts meta.brace.angle.ts
+   ^^^
+   source.ts cast.expr.ts entity.name.type.module.ts
+      ^
+      source.ts cast.expr.ts punctuation.accessor.ts
+       ^^^^
+       source.ts cast.expr.ts entity.name.type.ts
+           ^^
+           source.ts cast.expr.ts
+             ^
+             source.ts cast.expr.ts meta.brace.angle.ts
+              ^
+              source.ts meta.brace.round.ts
+               ^
+               source.ts punctuation.terminator.statement.ts
+>(<dot.View />);
+ ^
+ source.ts meta.brace.round.ts
+  ^
+  source.ts cast.expr.ts meta.brace.angle.ts
+   ^^^
+   source.ts cast.expr.ts entity.name.type.module.ts
+      ^
+      source.ts cast.expr.ts punctuation.accessor.ts
+       ^^^^
+       source.ts cast.expr.ts entity.name.type.ts
+           ^^
+           source.ts cast.expr.ts
+             ^
+             source.ts cast.expr.ts meta.brace.angle.ts
+              ^
+              source.ts meta.brace.round.ts
+               ^
+               source.ts punctuation.terminator.statement.ts
+>(<View></View>);
+ ^
+ source.ts meta.brace.round.ts
+  ^
+  source.ts cast.expr.ts meta.brace.angle.ts
+   ^^^^
+   source.ts cast.expr.ts entity.name.type.ts
+       ^
+       source.ts cast.expr.ts meta.brace.angle.ts
+        ^
+        source.ts cast.expr.ts meta.brace.angle.ts
+         ^
+         source.ts cast.expr.ts
+          ^^^^
+          source.ts cast.expr.ts entity.name.type.ts
+              ^
+              source.ts cast.expr.ts meta.brace.angle.ts
+               ^
+               source.ts meta.brace.round.ts
+                ^
+                source.ts punctuation.terminator.statement.ts
+>(<dot.View></dot.View>);
+ ^
+ source.ts meta.brace.round.ts
+  ^
+  source.ts cast.expr.ts meta.brace.angle.ts
+   ^^^
+   source.ts cast.expr.ts entity.name.type.module.ts
+      ^
+      source.ts cast.expr.ts punctuation.accessor.ts
+       ^^^^
+       source.ts cast.expr.ts entity.name.type.ts
+           ^
+           source.ts cast.expr.ts meta.brace.angle.ts
+            ^
+            source.ts cast.expr.ts meta.brace.angle.ts
+             ^
+             source.ts cast.expr.ts
+              ^^^
+              source.ts cast.expr.ts entity.name.type.module.ts
+                 ^
+                 source.ts cast.expr.ts punctuation.accessor.ts
+                  ^^^^
+                  source.ts cast.expr.ts entity.name.type.ts
+                      ^
+                      source.ts cast.expr.ts meta.brace.angle.ts
+                       ^
+                       source.ts meta.brace.round.ts
+                        ^
+                        source.ts punctuation.terminator.statement.ts
+>(<dot.View><b>bold</b></dot.View>);
+ ^
+ source.ts meta.brace.round.ts
+  ^
+  source.ts cast.expr.ts meta.brace.angle.ts
+   ^^^
+   source.ts cast.expr.ts entity.name.type.module.ts
+      ^
+      source.ts cast.expr.ts punctuation.accessor.ts
+       ^^^^
+       source.ts cast.expr.ts entity.name.type.ts
+           ^
+           source.ts cast.expr.ts meta.brace.angle.ts
+            ^
+            source.ts cast.expr.ts meta.brace.angle.ts
+             ^
+             source.ts cast.expr.ts entity.name.type.ts
+              ^
+              source.ts cast.expr.ts meta.brace.angle.ts
+               ^^^^
+               source.ts variable.other.readwrite.ts
+                   ^
+                   source.ts keyword.operator.relational.ts
+                    ^
+                    source.ts keyword.operator.arithmetic.ts
+                     ^
+                     source.ts variable.other.readwrite.ts
+                      ^
+                      source.ts keyword.operator.relational.ts
+                       ^
+                       source.ts cast.expr.ts meta.brace.angle.ts
+                        ^
+                        source.ts cast.expr.ts
+                         ^^^
+                         source.ts cast.expr.ts entity.name.type.module.ts
+                            ^
+                            source.ts cast.expr.ts punctuation.accessor.ts
+                             ^^^^
+                             source.ts cast.expr.ts entity.name.type.ts
+                                 ^
+                                 source.ts cast.expr.ts meta.brace.angle.ts
+                                  ^
+                                  source.ts meta.brace.round.ts
+                                   ^
+                                   source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/Issue415.baseline.txt
+++ b/tests/baselines/Issue415.baseline.txt
@@ -1,5 +1,6 @@
 original file
 -----------------------------------
+// @onlyOwnGrammar - As this has jsx
 (<View />);
 (<dot.view />);
 (<dot.View />);
@@ -11,6 +12,11 @@ original file
 
 Grammar: TypeScriptReact.tmLanguage
 -----------------------------------
+>// @onlyOwnGrammar - As this has jsx
+ ^^
+ source.tsx comment.line.double-slash.tsx punctuation.definition.comment.tsx
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   source.tsx comment.line.double-slash.tsx
 >(<View />);
  ^
  source.tsx meta.brace.round.tsx
@@ -142,174 +148,3 @@ Grammar: TypeScriptReact.tmLanguage
                                   source.tsx meta.brace.round.tsx
                                    ^
                                    source.tsx punctuation.terminator.statement.tsx
-
-
-Grammar: TypeScript.tmLanguage
------------------------------------
->(<View />);
- ^
- source.ts meta.brace.round.ts
-  ^
-  source.ts cast.expr.ts meta.brace.angle.ts
-   ^^^^
-   source.ts cast.expr.ts entity.name.type.ts
-       ^^
-       source.ts cast.expr.ts
-         ^
-         source.ts cast.expr.ts meta.brace.angle.ts
-          ^
-          source.ts meta.brace.round.ts
-           ^
-           source.ts punctuation.terminator.statement.ts
->(<dot.view />);
- ^
- source.ts meta.brace.round.ts
-  ^
-  source.ts cast.expr.ts meta.brace.angle.ts
-   ^^^
-   source.ts cast.expr.ts entity.name.type.module.ts
-      ^
-      source.ts cast.expr.ts punctuation.accessor.ts
-       ^^^^
-       source.ts cast.expr.ts entity.name.type.ts
-           ^^
-           source.ts cast.expr.ts
-             ^
-             source.ts cast.expr.ts meta.brace.angle.ts
-              ^
-              source.ts meta.brace.round.ts
-               ^
-               source.ts punctuation.terminator.statement.ts
->(<dot.View />);
- ^
- source.ts meta.brace.round.ts
-  ^
-  source.ts cast.expr.ts meta.brace.angle.ts
-   ^^^
-   source.ts cast.expr.ts entity.name.type.module.ts
-      ^
-      source.ts cast.expr.ts punctuation.accessor.ts
-       ^^^^
-       source.ts cast.expr.ts entity.name.type.ts
-           ^^
-           source.ts cast.expr.ts
-             ^
-             source.ts cast.expr.ts meta.brace.angle.ts
-              ^
-              source.ts meta.brace.round.ts
-               ^
-               source.ts punctuation.terminator.statement.ts
->(<dot.View />);
- ^
- source.ts meta.brace.round.ts
-  ^
-  source.ts cast.expr.ts meta.brace.angle.ts
-   ^^^
-   source.ts cast.expr.ts entity.name.type.module.ts
-      ^
-      source.ts cast.expr.ts punctuation.accessor.ts
-       ^^^^
-       source.ts cast.expr.ts entity.name.type.ts
-           ^^
-           source.ts cast.expr.ts
-             ^
-             source.ts cast.expr.ts meta.brace.angle.ts
-              ^
-              source.ts meta.brace.round.ts
-               ^
-               source.ts punctuation.terminator.statement.ts
->(<View></View>);
- ^
- source.ts meta.brace.round.ts
-  ^
-  source.ts cast.expr.ts meta.brace.angle.ts
-   ^^^^
-   source.ts cast.expr.ts entity.name.type.ts
-       ^
-       source.ts cast.expr.ts meta.brace.angle.ts
-        ^
-        source.ts cast.expr.ts meta.brace.angle.ts
-         ^
-         source.ts cast.expr.ts
-          ^^^^
-          source.ts cast.expr.ts entity.name.type.ts
-              ^
-              source.ts cast.expr.ts meta.brace.angle.ts
-               ^
-               source.ts meta.brace.round.ts
-                ^
-                source.ts punctuation.terminator.statement.ts
->(<dot.View></dot.View>);
- ^
- source.ts meta.brace.round.ts
-  ^
-  source.ts cast.expr.ts meta.brace.angle.ts
-   ^^^
-   source.ts cast.expr.ts entity.name.type.module.ts
-      ^
-      source.ts cast.expr.ts punctuation.accessor.ts
-       ^^^^
-       source.ts cast.expr.ts entity.name.type.ts
-           ^
-           source.ts cast.expr.ts meta.brace.angle.ts
-            ^
-            source.ts cast.expr.ts meta.brace.angle.ts
-             ^
-             source.ts cast.expr.ts
-              ^^^
-              source.ts cast.expr.ts entity.name.type.module.ts
-                 ^
-                 source.ts cast.expr.ts punctuation.accessor.ts
-                  ^^^^
-                  source.ts cast.expr.ts entity.name.type.ts
-                      ^
-                      source.ts cast.expr.ts meta.brace.angle.ts
-                       ^
-                       source.ts meta.brace.round.ts
-                        ^
-                        source.ts punctuation.terminator.statement.ts
->(<dot.View><b>bold</b></dot.View>);
- ^
- source.ts meta.brace.round.ts
-  ^
-  source.ts cast.expr.ts meta.brace.angle.ts
-   ^^^
-   source.ts cast.expr.ts entity.name.type.module.ts
-      ^
-      source.ts cast.expr.ts punctuation.accessor.ts
-       ^^^^
-       source.ts cast.expr.ts entity.name.type.ts
-           ^
-           source.ts cast.expr.ts meta.brace.angle.ts
-            ^
-            source.ts cast.expr.ts meta.brace.angle.ts
-             ^
-             source.ts cast.expr.ts entity.name.type.ts
-              ^
-              source.ts cast.expr.ts meta.brace.angle.ts
-               ^^^^
-               source.ts variable.other.readwrite.ts
-                   ^
-                   source.ts keyword.operator.relational.ts
-                    ^
-                    source.ts keyword.operator.arithmetic.ts
-                     ^
-                     source.ts variable.other.readwrite.ts
-                      ^
-                      source.ts keyword.operator.relational.ts
-                       ^
-                       source.ts cast.expr.ts meta.brace.angle.ts
-                        ^
-                        source.ts cast.expr.ts
-                         ^^^
-                         source.ts cast.expr.ts entity.name.type.module.ts
-                            ^
-                            source.ts cast.expr.ts punctuation.accessor.ts
-                             ^^^^
-                             source.ts cast.expr.ts entity.name.type.ts
-                                 ^
-                                 source.ts cast.expr.ts meta.brace.angle.ts
-                                  ^
-                                  source.ts meta.brace.round.ts
-                                   ^
-                                   source.ts punctuation.terminator.statement.ts

--- a/tests/baselines/TsxSamples.baseline.txt
+++ b/tests/baselines/TsxSamples.baseline.txt
@@ -202,7 +202,7 @@ Grammar: TypeScriptReact.tmLanguage
      ^
      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
       ^^^^
-      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
           ^
           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >        <FormRow>
@@ -211,7 +211,7 @@ Grammar: TypeScriptReact.tmLanguage
          ^
          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
           ^^^^^^^
-          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
                  ^
                  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >            <FormLabel data="1" />
@@ -220,7 +220,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
               ^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                        ^
                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
                         ^^^^
@@ -243,7 +243,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
               ^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                        ^
                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
                         ^^^^
@@ -266,7 +266,7 @@ Grammar: TypeScriptReact.tmLanguage
          ^^
          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
            ^^^^^^^
-           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
                   ^
                   source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >    </Form>
@@ -275,7 +275,7 @@ Grammar: TypeScriptReact.tmLanguage
      ^^
      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
        ^^^^
-       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
            ^
            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >
@@ -302,7 +302,7 @@ Grammar: TypeScriptReact.tmLanguage
      ^
      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
       ^^^^
-      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
           ^
           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >        <FormRow>
@@ -311,7 +311,7 @@ Grammar: TypeScriptReact.tmLanguage
          ^
          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
           ^^^^^^^
-          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
                  ^
                  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >            <FormLabel data='1' />
@@ -320,7 +320,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
               ^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                        ^
                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
                         ^^^^
@@ -343,7 +343,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
               ^^^^^^^^^
-              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                        ^
                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
                         ^^^^
@@ -366,7 +366,7 @@ Grammar: TypeScriptReact.tmLanguage
          ^^
          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
            ^^^^^^^
-           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
                   ^
                   source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >      </Form>
@@ -375,7 +375,7 @@ Grammar: TypeScriptReact.tmLanguage
        ^^
        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
          ^^^^
-         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >)
@@ -405,7 +405,7 @@ Grammar: TypeScriptReact.tmLanguage
      ^
      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
       ^^^
-      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
          ^
          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >        {/* child comment, put {} around */}
@@ -427,7 +427,7 @@ Grammar: TypeScriptReact.tmLanguage
          ^
          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
           ^^^^^^
-          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx
+          source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                 ^
                 source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx
                  ^^^^
@@ -477,7 +477,7 @@ Grammar: TypeScriptReact.tmLanguage
      ^^
      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
        ^^^
-       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx
+       source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx
           ^
           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
 >);
@@ -567,7 +567,7 @@ Grammar: TypeScriptReact.tmLanguage
                  ^
                  source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
                   ^^^^^^^^^
-                  source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx
+                  source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                            ^
                            source.tsx meta.var.expr.tsx meta.tag.tsx
                             ^
@@ -636,7 +636,7 @@ Grammar: TypeScriptReact.tmLanguage
                   ^
                   source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx
                    ^^^^^^^^^
-                   source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx
+                   source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx
                             ^
                             source.tsx meta.var.expr.tsx meta.tag.tsx
                              ^

--- a/tests/baselines/TsxSamples.txt
+++ b/tests/baselines/TsxSamples.txt
@@ -84,17 +84,17 @@ Grammar: TypeScriptReact.tmLanguage
      ^
      [13, 5]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
       ^^^^
-      [13, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+      [13, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >        <FormRow>
          ^
          [14, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
           ^^^^^^^
-          [14, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+          [14, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >            <FormLabel data="1" />
              ^
              [15, 13]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
               ^^^^^^^^^
-              [15, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+              [15, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx 
                         ^^^^
                         [15, 24]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.other.attribute-name.tsx 
                               ^
@@ -103,7 +103,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              [16, 13]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
               ^^^^^^^^^
-              [16, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+              [16, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx 
                         ^^^^
                         [16, 24]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.other.attribute-name.tsx 
                               ^
@@ -112,29 +112,29 @@ Grammar: TypeScriptReact.tmLanguage
          ^^
          [17, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
            ^^^^^^^
-           [17, 11]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+           [17, 11]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >    </Form>
      ^^
      [18, 5]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
        ^^^^
-       [18, 7]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+       [18, 7]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >
 >var App2 = (
 >    <Form>
      ^
      [21, 5]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
       ^^^^
-      [21, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+      [21, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >        <FormRow>
          ^
          [22, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
           ^^^^^^^
-          [22, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+          [22, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >            <FormLabel data='1' />
              ^
              [23, 13]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
               ^^^^^^^^^
-              [23, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+              [23, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx 
                         ^^^^
                         [23, 24]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.other.attribute-name.tsx 
                               ^
@@ -143,7 +143,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              [24, 13]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
               ^^^^^^^^^
-              [24, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+              [24, 14]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx 
                         ^^^^
                         [24, 24]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.other.attribute-name.tsx 
                               ^
@@ -152,12 +152,12 @@ Grammar: TypeScriptReact.tmLanguage
          ^^
          [25, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
            ^^^^^^^
-           [25, 11]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+           [25, 11]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >      </Form>
        ^^
        [26, 7]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
          ^^^^
-         [26, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+         [26, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >)
 >
 >var content = (
@@ -165,13 +165,13 @@ Grammar: TypeScriptReact.tmLanguage
      ^
      [30, 5]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx 
       ^^^
-      [30, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx 
+      [30, 6]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx entity.name.tag.tsx support.class.component.tsx 
 >        {/* child comment, put {} around */}
 >        <Person name={window.isLoggedIn ? window.name : ''}
          ^
          [32, 9]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
           ^^^^^^
-          [32, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx 
+          [32, 10]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx 
                  ^^^^
                  [32, 17]: source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx entity.other.attribute-name.tsx 
                        ^^^^^^
@@ -193,7 +193,7 @@ Grammar: TypeScriptReact.tmLanguage
                  ^
                  [42, 17]: source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
                   ^^^^^^^^^
-                  [42, 18]: source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx 
+                  [42, 18]: source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx 
                              ^^^
                              [42, 29]: source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx 
                                        ^^
@@ -204,7 +204,7 @@ Grammar: TypeScriptReact.tmLanguage
                   ^
                   [45, 18]: source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.begin.tsx 
                    ^^^^^^^^^
-                   [45, 19]: source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx 
+                   [45, 19]: source.tsx meta.var.expr.tsx meta.tag.tsx entity.name.tag.tsx support.class.component.tsx 
                               ^^^
                               [45, 30]: source.tsx meta.var.expr.tsx meta.tag.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx 
                                                          ^^

--- a/tests/cases/Issue415.tsx
+++ b/tests/cases/Issue415.tsx
@@ -1,0 +1,7 @@
+(<View />);
+(<dot.view />);
+(<dot.View />);
+(<dot.View />);
+(<View></View>);
+(<dot.View></dot.View>);
+(<dot.View><b>bold</b></dot.View>);

--- a/tests/cases/Issue415.tsx
+++ b/tests/cases/Issue415.tsx
@@ -1,3 +1,4 @@
+// @onlyOwnGrammar - As this has jsx
 (<View />);
 (<dot.view />);
 (<dot.View />);


### PR DESCRIPTION
Fixes #415

Adds an extra marker for tsx tags that are likly a javascript/typescript class instead of a standard html element. An element is marked as a class if it does not only contain lowercase letters

<img width="736" alt="screen shot 2017-05-03 at 8 15 25 pm" src="https://cloud.githubusercontent.com/assets/12821956/25689757/d45ae3d0-303f-11e7-8a7a-8a8d9777cd23.png">

