### PR TITLE
Remove non-standard text at beginning of license

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,3 @@
-
-TypeScript Grammar 
-
 Copyright (c) Microsoft Corporation
 All rights reserved.
 


### PR DESCRIPTION
Because of the non-standard text at the beginning of the license, it
cannot be automatically recognized by tools such as Licensee.

With this change, the license should be [displayed on the header of
the repository](https://github.com/blog/2252-license-now-displayed-on-repository-overview). It also makes it possible for [repositories using this
repository as a submodule](https://github.com/github/linguist/pull/3730) to automatically whitelist its license.