### PR TITLE
Better support for template string grammar injections

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -1927,6 +1927,12 @@ repository:
 
   template:
     name: string.template.ts
+    begin: '(?=([_$[:alpha:]][_$[:alnum:]]*)?`)'
+    end: '(?<=`)'
+    patterns:
+     - include: '#standard-template-string'
+
+  standard-template-string:
     begin: '([_$[:alpha:]][_$[:alnum:]]*)?(`)'
     beginCaptures:
       '1': { name: entity.name.function.tagged-template.ts }

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -5304,6 +5304,20 @@
         <key>name</key>
         <string>string.template.ts</string>
         <key>begin</key>
+        <string>(?=([_$[:alpha:]][_$[:alnum:]]*)?`)</string>
+        <key>end</key>
+        <string>(?&lt;=`)</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#standard-template-string</string>
+          </dict>
+        </array>
+      </dict>
+      <key>standard-template-string</key>
+      <dict>
+        <key>begin</key>
         <string>([_$[:alpha:]][_$[:alnum:]]*)?(`)</string>
         <key>beginCaptures</key>
         <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -5250,6 +5250,20 @@
         <key>name</key>
         <string>string.template.tsx</string>
         <key>begin</key>
+        <string>(?=([_$[:alpha:]][_$[:alnum:]]*)?`)</string>
+        <key>end</key>
+        <string>(?&lt;=`)</string>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#standard-template-string</string>
+          </dict>
+        </array>
+      </dict>
+      <key>standard-template-string</key>
+      <dict>
+        <key>begin</key>
         <string>([_$[:alpha:]][_$[:alnum:]]*)?(`)</string>
         <key>beginCaptures</key>
         <dict>


### PR DESCRIPTION
Fixes #503

Allows for extension authors to more easily inject grammars for template strings. The change splits the template definition in two: a top level pattern to be targeted by the injection, and a standard implementation for js/ts template strings.