### PR TITLE
Move generateScopes into `it` for tests

### DIFF
--- a/tests/test.ts
+++ b/tests/test.ts
@@ -22,27 +22,27 @@ ensureCleanGeneratedFolder();
 // Generate the new baselines
 for (const fileName of fs.readdirSync('cases')) {
     describe("Generating baseline for " + fileName, () => {
-        const text = fs.readFileSync(path.join('./cases', fileName), 'utf8');
-        const parsedFileName = path.parse(fileName);
-        const { markerScopes, wholeBaseline } = build.generateScopes(text, parsedFileName);
-        if (markerScopes) {
-            addTestCase(parsedFileName.name + '.txt', markerScopes);
-        }
-        addTestCase(parsedFileName.name + '.baseline.txt', wholeBaseline);
+        it('Comparing generated', () => {
+            const text = fs.readFileSync(path.join('./cases', fileName), 'utf8');
+            const parsedFileName = path.parse(fileName);
+            const { markerScopes, wholeBaseline } = build.generateScopes(text, parsedFileName);
+            if (markerScopes) {
+                assertBaselinesMatch(parsedFileName.name + '.txt', markerScopes);
+            }
+            assertBaselinesMatch(parsedFileName.name + '.baseline.txt', wholeBaseline);
+        });
     });
 }
 
-function addTestCase(file: string, generatedText: string) {
+function assertBaselinesMatch(file: string, generatedText: string) {
     const generatedFileName = path.join(generatedFolder, file);
     fs.writeFileSync(generatedFileName, generatedText);
 
-    it('Comparing generated' + file, () => {
-        const baselineFile = path.join(baselineFolder, file);
-        if (fs.existsSync(baselineFile)) {
-            chai.assert.equal(generatedText, fs.readFileSync(baselineFile, 'utf8'), "Expected baselines to match");
-        }
-        else {
-            chai.assert(false, "New generated baseline");
-        }
-    });
+    const baselineFile = path.join(baselineFolder, file);
+    if (fs.existsSync(baselineFile)) {
+        chai.assert.equal(generatedText, fs.readFileSync(baselineFile, 'utf8'), "Expected baselines to match: " + file);
+    }
+    else {
+        chai.assert(false, "New generated baseline");
+    }
 }

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -21,27 +21,24 @@ ensureCleanGeneratedFolder();
 
 // Generate the new baselines
 for (const fileName of fs.readdirSync('cases')) {
-    describe("Generating baseline for " + fileName, () => {
-        const text = fs.readFileSync(path.join('./cases', fileName), 'utf8');
-        const parsedFileName = path.parse(fileName);
+    const text = fs.readFileSync(path.join('./cases', fileName), 'utf8');
+    const parsedFileName = path.parse(fileName);
 
-        const generateScopes = (() => {
-            let result: { markerScopes: string, wholeBaseline: string };
-            return () => {
-                if (!result) {
-                    result = build.generateScopes(text, parsedFileName);
-                }
-                return result;
-            }
-        })();
-        
+    let wholeBaseline: string;
+    let markerScopes: string;
+
+    describe("Generating baseline for " + fileName, () => {
+        before(() =>  {
+            const result = build.generateScopes(text, parsedFileName)
+            wholeBaseline = result.wholeBaseline;
+            markerScopes = result.markerScopes;
+        });
+
         it('Comparing generated', () => {
-            const { markerScopes, wholeBaseline } = generateScopes();
             assertBaselinesMatch(parsedFileName.name + '.baseline.txt', wholeBaseline);
         });
 
         it('Comparing generated scopes', () => {
-            const { markerScopes } = generateScopes();
             if (markerScopes) {
                 assertBaselinesMatch(parsedFileName.name + '.txt', markerScopes);
             }


### PR DESCRIPTION
**Bug**
In the tests, if one of the tests causes a hang, the entire test suite will hang. This is because `generateScopes` is being run in the `describe` block, instead of inside one of the tests themselves

**Fix**
Move `generateScopes` into the `it` block of the test