### PR TITLE
Use __dirname in tests so that cwd doesn't matter

### DIFF
--- a/tests/build.ts
+++ b/tests/build.ts
@@ -5,8 +5,8 @@ const tsGrammarFileName = "TypeScript.tmLanguage"
 const tsReactGrammarFileName = "TypeScriptReact.tmLanguage"
 
 const register = new vt.Registry();
-const tsGrammar = register.loadGrammarFromPathSync("../" + tsGrammarFileName);
-const tsReactGrammar = register.loadGrammarFromPathSync("../" + tsReactGrammarFileName);
+const tsGrammar = register.loadGrammarFromPathSync(path.join(__dirname, '..', tsGrammarFileName));
+const tsReactGrammar = register.loadGrammarFromPathSync(path.join(__dirname, '..', tsReactGrammarFileName));
 
 const marker = '^^';
 

--- a/tests/test.ts
+++ b/tests/test.ts
@@ -3,8 +3,9 @@ import path = require('path');
 import chai = require('chai');
 import build = require('./build');
 
-const generatedFolder = "generated";
-const baselineFolder = "baselines";
+const generatedFolder = path.join(__dirname, 'generated');
+const baselineFolder = path.join(__dirname, 'baselines');
+const casesFolder = path.join(__dirname, 'cases');
 
 function ensureCleanGeneratedFolder() {
     if (fs.existsSync(generatedFolder)) {
@@ -20,8 +21,8 @@ function ensureCleanGeneratedFolder() {
 ensureCleanGeneratedFolder();
 
 // Generate the new baselines
-for (const fileName of fs.readdirSync('cases')) {
-    const text = fs.readFileSync(path.join('./cases', fileName), 'utf8');
+for (const fileName of fs.readdirSync(casesFolder)) {
+    const text = fs.readFileSync(path.join(casesFolder, fileName), 'utf8');
     const parsedFileName = path.parse(fileName);
 
     let wholeBaseline: string;


### PR DESCRIPTION
Update relative paths in tests to use `__dirname` when constructing the path. This allows running the tests without changing the cwd to `./tests`