### PR TITLE
fix error in TS.YAML in method-declaration-name

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -507,7 +507,7 @@ repository:
     patterns:
     - include: '#string'
     - include: '#array-literal'
-    - name: meta.definition.method.ts entity.name.function.ts
+    - name: meta.definition.method.entity.name.function.ts
       match: '{{identifier}}'
     - name: keyword.operator.optional.ts
       match: \?

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -1566,7 +1566,7 @@
           </dict>
           <dict>
             <key>name</key>
-            <string>meta.definition.method.ts entity.name.function.ts</string>
+            <string>meta.definition.method.entity.name.function.ts</string>
             <key>match</key>
             <string>[_$[:alpha:]][_$[:alnum:]]*</string>
           </dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -1570,7 +1570,7 @@
           </dict>
           <dict>
             <key>name</key>
-            <string>meta.definition.method.tsx entity.name.function.tsx</string>
+            <string>meta.definition.method.entity.name.function.tsx</string>
             <key>match</key>
             <string>[_$[:alpha:]][_$[:alnum:]]*</string>
           </dict>


### PR DESCRIPTION
fixes #544 

My first contribution, so apologies if I didn't update your tests or something. They were confusing - `cd test; npm test` had test failures and `npm run diff` threw a `/bin/sh: baselines: command not found` error so I'm not sure if I'm missing something. Still, the diff shows 3 lines changed - 1 in ts.yaml that I changed and the corresponding 2 lines in the generated ts.xml and tsx.xml files. So I'm fairly certain that things are as they should be.