### PR TITLE
Mark import paths with meta.import.path.ts

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -936,6 +936,7 @@ repository:
     patterns:
     - include: '#import-path-string-double'
     - include: '#import-path-string-single'
+    - include: '#string'
 
   import-path-string-double:
     name: string.quoted.double.ts

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -895,7 +895,7 @@ repository:
   import-export-declaration:
     patterns:
     - include: '#comment'
-    - include: '#string'
+    - include: '#import-path'
     - include: '#import-export-block'
     - name: keyword.control.from.ts
       match: \bfrom\b
@@ -931,6 +931,37 @@ repository:
       match: \b(default)\b
     - name: variable.other.readwrite.alias.ts
       match: ({{identifier}})
+
+  import-path:
+    patterns:
+    - include: '#import-path-string-double'
+    - include: '#import-path-string-single'
+
+  import-path-string-double:
+    name: string.quoted.double.ts
+    contentName: meta.import.path.ts
+    begin: '"'
+    beginCaptures:
+      '0': { name: punctuation.definition.string.begin.ts }
+    end: '(")|((?:[^\\\n])$)'
+    endCaptures:
+      '1': { name: punctuation.definition.string.end.ts }
+      '2': { name: invalid.illegal.newline.ts }
+    patterns:
+    - include: '#string-character-escape'
+
+  import-path-string-single:
+    name: string.quoted.single.ts
+    contentName: meta.import.path.ts
+    begin: "'"
+    beginCaptures:
+      '0': { name: punctuation.definition.string.begin.ts }
+    end: (\')|((?:[^\\\n])$)
+    endCaptures:
+      '1': { name: punctuation.definition.string.end.ts }
+      '2': { name: invalid.illegal.newline.ts }
+    patterns:
+    - include: '#string-character-escape'
 
   #control statements and loops
   switch-statement:

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -2798,7 +2798,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#string</string>
+            <string>#import-path</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2914,6 +2914,98 @@
             <string>variable.other.readwrite.alias.ts</string>
             <key>match</key>
             <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
+          </dict>
+        </array>
+      </dict>
+      <key>import-path</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#import-path-string-double</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#import-path-string-single</string>
+          </dict>
+        </array>
+      </dict>
+      <key>import-path-string-double</key>
+      <dict>
+        <key>name</key>
+        <string>string.quoted.double.ts</string>
+        <key>contentName</key>
+        <string>meta.import.path.ts</string>
+        <key>begin</key>
+        <string>"</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.begin.ts</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(")|((?:[^\\\n])$)</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.end.ts</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>invalid.illegal.newline.ts</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#string-character-escape</string>
+          </dict>
+        </array>
+      </dict>
+      <key>import-path-string-single</key>
+      <dict>
+        <key>name</key>
+        <string>string.quoted.single.ts</string>
+        <key>contentName</key>
+        <string>meta.import.path.ts</string>
+        <key>begin</key>
+        <string>'</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.begin.ts</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(\')|((?:[^\\\n])$)</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.end.ts</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>invalid.illegal.newline.ts</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#string-character-escape</string>
           </dict>
         </array>
       </dict>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -2929,6 +2929,10 @@
             <key>include</key>
             <string>#import-path-string-single</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#string</string>
+          </dict>
         </array>
       </dict>
       <key>import-path-string-double</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -2802,7 +2802,7 @@
           </dict>
           <dict>
             <key>include</key>
-            <string>#string</string>
+            <string>#import-path</string>
           </dict>
           <dict>
             <key>include</key>
@@ -2918,6 +2918,98 @@
             <string>variable.other.readwrite.alias.tsx</string>
             <key>match</key>
             <string>([_$[:alpha:]][_$[:alnum:]]*)</string>
+          </dict>
+        </array>
+      </dict>
+      <key>import-path</key>
+      <dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#import-path-string-double</string>
+          </dict>
+          <dict>
+            <key>include</key>
+            <string>#import-path-string-single</string>
+          </dict>
+        </array>
+      </dict>
+      <key>import-path-string-double</key>
+      <dict>
+        <key>name</key>
+        <string>string.quoted.double.tsx</string>
+        <key>contentName</key>
+        <string>meta.import.path.tsx</string>
+        <key>begin</key>
+        <string>"</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.begin.tsx</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(")|((?:[^\\\n])$)</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.end.tsx</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>invalid.illegal.newline.tsx</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#string-character-escape</string>
+          </dict>
+        </array>
+      </dict>
+      <key>import-path-string-single</key>
+      <dict>
+        <key>name</key>
+        <string>string.quoted.single.tsx</string>
+        <key>contentName</key>
+        <string>meta.import.path.tsx</string>
+        <key>begin</key>
+        <string>'</string>
+        <key>beginCaptures</key>
+        <dict>
+          <key>0</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.begin.tsx</string>
+          </dict>
+        </dict>
+        <key>end</key>
+        <string>(\')|((?:[^\\\n])$)</string>
+        <key>endCaptures</key>
+        <dict>
+          <key>1</key>
+          <dict>
+            <key>name</key>
+            <string>punctuation.definition.string.end.tsx</string>
+          </dict>
+          <key>2</key>
+          <dict>
+            <key>name</key>
+            <string>invalid.illegal.newline.tsx</string>
+          </dict>
+        </dict>
+        <key>patterns</key>
+        <array>
+          <dict>
+            <key>include</key>
+            <string>#string-character-escape</string>
           </dict>
         </array>
       </dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -2933,6 +2933,10 @@
             <key>include</key>
             <string>#import-path-string-single</string>
           </dict>
+          <dict>
+            <key>include</key>
+            <string>#string</string>
+          </dict>
         </array>
       </dict>
       <key>import-path-string-double</key>

--- a/tests/baselines/Issue143.baseline.txt
+++ b/tests/baselines/Issue143.baseline.txt
@@ -53,7 +53,7 @@ Grammar: TypeScript.tmLanguage
                                                   ^
                                                   source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                                    ^^^^^^^^^^^^^
-                                                   source.ts meta.import.ts string.quoted.single.ts
+                                                   source.ts meta.import.ts string.quoted.single.ts meta.import.path.ts
                                                                 ^
                                                                 source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                                                  ^

--- a/tests/baselines/Issue153.baseline.txt
+++ b/tests/baselines/Issue153.baseline.txt
@@ -87,7 +87,7 @@ Grammar: TypeScript.tmLanguage
                                ^
                                source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                 ^^^^^^^
-                                source.ts meta.import.ts string.quoted.single.ts
+                                source.ts meta.import.ts string.quoted.single.ts meta.import.path.ts
                                        ^
                                        source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                         ^

--- a/tests/baselines/Issue283.baseline.txt
+++ b/tests/baselines/Issue283.baseline.txt
@@ -58,7 +58,7 @@ Grammar: TypeScriptReact.tmLanguage
                         ^
                         source.tsx meta.import.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                          ^^^^^
-                         source.tsx meta.import.tsx string.quoted.single.tsx
+                         source.tsx meta.import.tsx string.quoted.single.tsx meta.import.path.tsx
                               ^
                               source.tsx meta.import.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                ^

--- a/tests/baselines/Issue37.baseline.txt
+++ b/tests/baselines/Issue37.baseline.txt
@@ -104,7 +104,7 @@ Grammar: TypeScript.tmLanguage
                       ^
                       source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                        ^^^^^^^^^^
-                       source.ts meta.import.ts string.quoted.double.ts
+                       source.ts meta.import.ts string.quoted.double.ts meta.import.path.ts
                                  ^
                                  source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.end.ts
 >import { Scale } from "./scale";
@@ -131,7 +131,7 @@ Grammar: TypeScript.tmLanguage
                        ^
                        source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                         ^^^^^^^
-                        source.ts meta.import.ts string.quoted.double.ts
+                        source.ts meta.import.ts string.quoted.double.ts meta.import.path.ts
                                ^
                                source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                 ^

--- a/tests/baselines/Issue387.baseline.txt
+++ b/tests/baselines/Issue387.baseline.txt
@@ -133,7 +133,7 @@ Grammar: TypeScript.tmLanguage
                                ^
                                source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                                 ^^^^^^^^
-                                source.ts meta.import.ts string.quoted.single.ts
+                                source.ts meta.import.ts string.quoted.single.ts meta.import.path.ts
                                         ^
                                         source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.end.ts
                                          ^

--- a/tests/baselines/Issue485.baseline.txt
+++ b/tests/baselines/Issue485.baseline.txt
@@ -22,7 +22,7 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                 ^
-                source.ts meta.import.ts string.quoted.single.ts
+                source.ts meta.import.ts string.quoted.single.ts meta.import.path.ts
                  ^
                  source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.end.ts
                   ^
@@ -47,6 +47,6 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.begin.ts
                 ^
-                source.ts meta.import.ts string.quoted.single.ts
+                source.ts meta.import.ts string.quoted.single.ts meta.import.path.ts
                  ^
                  source.ts meta.import.ts string.quoted.single.ts punctuation.definition.string.end.ts

--- a/tests/baselines/exportDeclarations.baseline.txt
+++ b/tests/baselines/exportDeclarations.baseline.txt
@@ -56,7 +56,7 @@ Grammar: TypeScript.tmLanguage
                ^
                source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                 ^^^^^^^^^^^^^
-                source.ts meta.export.ts string.quoted.double.ts
+                source.ts meta.export.ts string.quoted.double.ts meta.import.path.ts
                              ^
                              source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
                               ^
@@ -101,7 +101,7 @@ Grammar: TypeScript.tmLanguage
                            ^
                            source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
                             ^^^^^^^^^^^^^
-                            source.ts meta.export.ts string.quoted.double.ts
+                            source.ts meta.export.ts string.quoted.double.ts meta.import.path.ts
                                          ^
                                          source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
                                           ^


### PR DESCRIPTION
Fixes #582

Adds a new meta scope to the contents of import paths: `meta.import.path`