### PR TITLE
Add s (single line) flag to js/ts regex

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -2030,10 +2030,10 @@ repository:
   regex:
     patterns:
     - name: string.regexp.ts
-      begin: (?<=[=(:,\[?+!]|{{lookBehindReturn}}|{{lookBehindCase}}|=>|&&|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuy]*(?!\s*[a-zA-Z0-9_$]))
+      begin: (?<=[=(:,\[?+!]|{{lookBehindReturn}}|{{lookBehindCase}}|=>|&&|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuys]*(?!\s*[a-zA-Z0-9_$]))
       beginCaptures:
         '1': {name: punctuation.definition.string.begin.ts}
-      end: (/)([gimuy]*)
+      end: (/)([gimuys]*)
       endCaptures:
         '1': {name: punctuation.definition.string.end.ts}
         '2': {name: keyword.other.ts}
@@ -2041,10 +2041,10 @@ repository:
       - include: '#regexp'
     # Check if complete regexp syntax
     - name: string.regexp.ts
-      begin: (?<![_$[:alnum:])\]])\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuy]*(?!\s*[a-zA-Z0-9_$]))
+      begin: (?<![_$[:alnum:])\]])\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuys]*(?!\s*[a-zA-Z0-9_$]))
       beginCaptures:
         '0': {name: punctuation.definition.string.begin.ts}
-      end: (/)([gimuy]*)
+      end: (/)([gimuys]*)
       endCaptures:
         '1': {name: punctuation.definition.string.end.ts}
         '2': {name: keyword.other.ts}

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -5724,7 +5724,7 @@
             <key>name</key>
             <string>string.regexp.ts</string>
             <key>begin</key>
-            <string>(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuy]*(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuys]*(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -5734,7 +5734,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimuy]*)</string>
+            <string>(/)([gimuys]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>
@@ -5760,7 +5760,7 @@
             <key>name</key>
             <string>string.regexp.ts</string>
             <key>begin</key>
-            <string>(?&lt;![_$[:alnum:])\]])\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuy]*(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;![_$[:alnum:])\]])\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuys]*(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -5770,7 +5770,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimuy]*)</string>
+            <string>(/)([gimuys]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -5670,7 +5670,7 @@
             <key>name</key>
             <string>string.regexp.tsx</string>
             <key>begin</key>
-            <string>(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuy]*(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuys]*(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -5680,7 +5680,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimuy]*)</string>
+            <string>(/)([gimuys]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>
@@ -5706,7 +5706,7 @@
             <key>name</key>
             <string>string.regexp.tsx</string>
             <key>begin</key>
-            <string>(?&lt;![_$[:alnum:])\]])\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuy]*(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;![_$[:alnum:])\]])\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)+\])+\/(?![\/*])[gimuys]*(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -5716,7 +5716,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimuy]*)</string>
+            <string>(/)([gimuys]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>


### PR DESCRIPTION
While not in the js/ts documentation, Chrome 64.0.3282.186 and Node 8.9.4 do support the `s` regex flag, as well as it being a suggested flag for [regex101](https://regex101.com). I feel that these are popular enough to justify adding it to the styling for the js/ts extensions.
I have tested IE, Edge and Firefox, however none of them appear to support the `s` flag.

I originally made this as a [PR for vscode](https://github.com/Microsoft/vscode/pull/46358) and was directed to this one