### PR TITLE
Separate control flow from loops and try catch

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -153,10 +153,14 @@ repository:
     patterns:
     - include: '#switch-statement'
     - include: '#for-loop'
+    - name: keyword.control.trycatch.flow.ts
+      match: '{{startOfIdentifier}}(throw){{endOfIdentifier}}'
     - name: keyword.control.trycatch.ts
-      match: '{{startOfIdentifier}}(catch|finally|throw|try){{endOfIdentifier}}'
+      match: '{{startOfIdentifier}}(catch|finally|try){{endOfIdentifier}}'
+    - name: keyword.control.loop.flow.ts
+      match: '{{startOfIdentifier}}(break|continue|goto){{endOfIdentifier}}'
     - name: keyword.control.loop.ts
-      match: '{{startOfIdentifier}}(break|continue|do|goto|while){{endOfIdentifier}}'
+      match: '{{startOfIdentifier}}(do|while){{endOfIdentifier}}'
     - name: keyword.control.flow.ts
       match: '{{startOfIdentifier}}(return){{endOfIdentifier}}'
     - name: keyword.control.switch.ts

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -149,15 +149,27 @@
           </dict>
           <dict>
             <key>name</key>
+            <string>keyword.control.trycatch.flow.ts</string>
+            <key>match</key>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(throw)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+          </dict>
+          <dict>
+            <key>name</key>
             <string>keyword.control.trycatch.ts</string>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(catch|finally|throw|try)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(catch|finally|try)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.loop.flow.ts</string>
+            <key>match</key>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(break|continue|goto)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
           </dict>
           <dict>
             <key>name</key>
             <string>keyword.control.loop.ts</string>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(break|continue|do|goto|while)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(do|while)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
           </dict>
           <dict>
             <key>name</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -149,15 +149,27 @@
           </dict>
           <dict>
             <key>name</key>
+            <string>keyword.control.trycatch.flow.tsx</string>
+            <key>match</key>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(throw)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+          </dict>
+          <dict>
+            <key>name</key>
             <string>keyword.control.trycatch.tsx</string>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(catch|finally|throw|try)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(catch|finally|try)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+          </dict>
+          <dict>
+            <key>name</key>
+            <string>keyword.control.loop.flow.tsx</string>
+            <key>match</key>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(break|continue|goto)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
           </dict>
           <dict>
             <key>name</key>
             <string>keyword.control.loop.tsx</string>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(break|continue|do|goto|while)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(do|while)(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.))</string>
           </dict>
           <dict>
             <key>name</key>

--- a/tests/baselines/FunctionMethodOverloads.baseline.txt
+++ b/tests/baselines/FunctionMethodOverloads.baseline.txt
@@ -285,7 +285,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.function.ts meta.block.ts
      ^^^^^
-     source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts
+     source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts
           ^
           source.ts meta.function.ts meta.block.ts
            ^^^
@@ -548,7 +548,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.function.ts meta.block.ts
      ^^^^^
-     source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts
+     source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts
           ^
           source.ts meta.function.ts meta.block.ts
            ^^^
@@ -806,7 +806,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
          ^^^^^
-         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts
+         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts
               ^
               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                ^^^
@@ -1059,7 +1059,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
          ^^^^^
-         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts
+         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts
               ^
               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                ^^^

--- a/tests/baselines/FunctionMethodOverloads.txt
+++ b/tests/baselines/FunctionMethodOverloads.txt
@@ -87,7 +87,7 @@ Grammar: TypeScript.tmLanguage
                  [7, 17]: source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts 
 >    throw new Error("")
      ^^^^^
-     [8, 5]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts 
+     [8, 5]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >}
 >
 >export function testFunctionOverloadWithSemicolon(p: number): new () => any;
@@ -122,7 +122,7 @@ Grammar: TypeScript.tmLanguage
                  [16, 17]: source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts 
 >    throw new Error("")
      ^^^^^
-     [17, 5]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts 
+     [17, 5]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >}
 >
 >
@@ -160,7 +160,7 @@ Grammar: TypeScript.tmLanguage
             [28, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.definition.method.ts entity.name.function.ts 
 >        throw new Error("")
          ^^^^^
-         [29, 9]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts 
+         [29, 9]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >    }
 >
 >    public testMethodOverloadWithSemicolon(p: number): new () => any;
@@ -195,7 +195,7 @@ Grammar: TypeScript.tmLanguage
             [37, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.definition.method.ts entity.name.function.ts 
 >        throw new Error("")
          ^^^^^
-         [38, 9]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts 
+         [38, 9]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >    }
 >}
 >

--- a/tests/baselines/FunctionMethodReturnTypes.baseline.txt
+++ b/tests/baselines/FunctionMethodReturnTypes.baseline.txt
@@ -403,7 +403,7 @@ Grammar: TypeScript.tmLanguage
                                                               ^
                                                               source.ts meta.function.ts meta.block.ts
                                                                ^^^^^
-                                                               source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts
+                                                               source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                                     ^
                                                                     source.ts meta.function.ts meta.block.ts
                                                                      ^^^
@@ -468,7 +468,7 @@ Grammar: TypeScript.tmLanguage
                                                             ^
                                                             source.ts meta.function.ts meta.block.ts
                                                              ^^^^^
-                                                             source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts
+                                                             source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                                   ^
                                                                   source.ts meta.function.ts meta.block.ts
                                                                    ^^^
@@ -539,7 +539,7 @@ Grammar: TypeScript.tmLanguage
                                                                ^
                                                                source.ts meta.function.ts meta.block.ts
                                                                 ^^^^^
-                                                                source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts
+                                                                source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                                      ^
                                                                      source.ts meta.function.ts meta.block.ts
                                                                       ^^^
@@ -626,7 +626,7 @@ Grammar: TypeScript.tmLanguage
                                                                              ^
                                                                              source.ts meta.function.ts meta.block.ts
                                                                               ^^^^^
-                                                                              source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts
+                                                                              source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                                                    ^
                                                                                    source.ts meta.function.ts meta.block.ts
                                                                                     ^^^
@@ -1299,7 +1299,7 @@ Grammar: TypeScript.tmLanguage
                                                        ^
                                                        source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                         ^^^^^
-                                                        source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts
+                                                        source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                              ^
                                                              source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                               ^^^
@@ -1362,7 +1362,7 @@ Grammar: TypeScript.tmLanguage
                                                      ^
                                                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                       ^^^^^
-                                                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts
+                                                      source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                            ^
                                                            source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                             ^^^
@@ -1431,7 +1431,7 @@ Grammar: TypeScript.tmLanguage
                                                         ^
                                                         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                          ^^^^^
-                                                         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts
+                                                         source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                               ^
                                                               source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                                ^^^
@@ -1516,7 +1516,7 @@ Grammar: TypeScript.tmLanguage
                                                                       ^
                                                                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                                        ^^^^^
-                                                                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts
+                                                                       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                                             ^
                                                                             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
                                                                              ^^^

--- a/tests/baselines/FunctionMethodReturnTypes.txt
+++ b/tests/baselines/FunctionMethodReturnTypes.txt
@@ -77,28 +77,28 @@ Grammar: TypeScript.tmLanguage
                  ^^^^^^^^^^^^^^^^^^^^^^^
                  [7, 17]: source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts 
                                                                ^^^^^
-                                                               [7, 63]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts 
+                                                               [7, 63]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >export function testFunctionReturnType7(): (() => number) { throw new Error(""); }
  ^^^^^^
  [8, 1]: source.ts meta.function.ts keyword.control.export.ts 
                  ^^^^^^^^^^^^^^^^^^^^^^^
                  [8, 17]: source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts 
                                                              ^^^^^
-                                                             [8, 61]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts 
+                                                             [8, 61]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >export function testFunctionReturnType8(): (() => number) [] { throw new Error(""); }
  ^^^^^^
  [9, 1]: source.ts meta.function.ts keyword.control.export.ts 
                  ^^^^^^^^^^^^^^^^^^^^^^^
                  [9, 17]: source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts 
                                                                 ^^^^^
-                                                                [9, 64]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts 
+                                                                [9, 64]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >export function testFunctionReturnType9(): (() => number) | (() => string) { throw new Error(""); }
  ^^^^^^
  [10, 1]: source.ts meta.function.ts keyword.control.export.ts 
                  ^^^^^^^^^^^^^^^^^^^^^^^
                  [10, 17]: source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts 
                                                                               ^^^^^
-                                                                              [10, 78]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts 
+                                                                              [10, 78]: source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >export function testFunctionReturnType10(): {a: A, b: B} [] { return [{a: {m: "" }, b: {m1: "" }}] }
  ^^^^^^
  [11, 1]: source.ts meta.function.ts keyword.control.export.ts 
@@ -171,28 +171,28 @@ Grammar: TypeScript.tmLanguage
             ^^^^^^^^^^^^^^^^^^^^^
             [23, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.definition.method.ts entity.name.function.ts 
                                                         ^^^^^
-                                                        [23, 56]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts 
+                                                        [23, 56]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >    public testMethodReturnType7(): (() => number) { throw new Error(""); }
      ^^^^^^
      [24, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^^^^
             [24, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.definition.method.ts entity.name.function.ts 
                                                       ^^^^^
-                                                      [24, 54]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts 
+                                                      [24, 54]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >    public testMethodReturnType8(): (() => number) [] { throw new Error(""); }
      ^^^^^^
      [25, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^^^^
             [25, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.definition.method.ts entity.name.function.ts 
                                                          ^^^^^
-                                                         [25, 57]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts 
+                                                         [25, 57]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >    public testMethodReturnType9(): (() => number) | (() => string) { throw new Error(""); }
      ^^^^^^
      [26, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 
             ^^^^^^^^^^^^^^^^^^^^^
             [26, 12]: source.ts meta.class.ts meta.method.declaration.ts meta.definition.method.ts entity.name.function.ts 
                                                                        ^^^^^
-                                                                       [26, 71]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts 
+                                                                       [26, 71]: source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts 
 >    public testMethodReturnType10(): {a: A, b: B} [] { return [{a: {m: "" }, b: {m1: "" }}] }
      ^^^^^^
      [27, 5]: source.ts meta.class.ts meta.method.declaration.ts storage.modifier.ts 

--- a/tests/baselines/Issue153.baseline.txt
+++ b/tests/baselines/Issue153.baseline.txt
@@ -649,7 +649,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts
              ^^^^^
-             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts keyword.control.trycatch.ts
+             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts keyword.control.trycatch.flow.ts
                   ^
                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts
                    ^^^
@@ -1027,7 +1027,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts
              ^^^^^
-             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts keyword.control.trycatch.ts
+             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts keyword.control.trycatch.flow.ts
                   ^
                   source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts
                    ^^^

--- a/tests/baselines/Issue223.baseline.txt
+++ b/tests/baselines/Issue223.baseline.txt
@@ -89,7 +89,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.block.ts meta.block.ts
      ^^^^^
-     source.ts meta.block.ts meta.block.ts keyword.control.loop.ts
+     source.ts meta.block.ts meta.block.ts keyword.control.loop.flow.ts
           ^^
           source.ts meta.block.ts meta.block.ts
 >  }

--- a/tests/baselines/Issue243.baseline.txt
+++ b/tests/baselines/Issue243.baseline.txt
@@ -282,7 +282,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -351,7 +351,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -420,7 +420,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -489,7 +489,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -558,7 +558,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -627,7 +627,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -696,7 +696,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -765,7 +765,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -834,7 +834,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -903,7 +903,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -972,7 +972,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1041,7 +1041,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1110,7 +1110,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1179,7 +1179,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1248,7 +1248,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1317,7 +1317,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1386,7 +1386,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1455,7 +1455,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1524,7 +1524,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1593,7 +1593,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1662,7 +1662,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1731,7 +1731,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1800,7 +1800,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1869,7 +1869,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -1938,7 +1938,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2007,7 +2007,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2076,7 +2076,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2145,7 +2145,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2214,7 +2214,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2283,7 +2283,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2352,7 +2352,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2421,7 +2421,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >                case /^\"?Accession\"?/.test(pieces[i]):
@@ -2490,7 +2490,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^^^^^^^^^^^^^^^
  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
                      ^^^^^
-                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+                     source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                           ^
                           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >            }

--- a/tests/baselines/Issue335.baseline.txt
+++ b/tests/baselines/Issue335.baseline.txt
@@ -345,7 +345,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
      ^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
           ^
           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >		}
@@ -497,7 +497,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
      ^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
           ^
           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >		}

--- a/tests/baselines/Issue37.baseline.txt
+++ b/tests/baselines/Issue37.baseline.txt
@@ -329,7 +329,7 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
            ^^^^^
-           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                 ^
                 source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >		case 2: break;
@@ -346,7 +346,7 @@ Grammar: TypeScript.tmLanguage
           ^
           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
            ^^^^^
-           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+           source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                 ^
                 source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >		default: break;
@@ -359,7 +359,7 @@ Grammar: TypeScript.tmLanguage
            ^
            source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts
             ^^^^^
-            source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.ts
+            source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts keyword.control.loop.flow.ts
                  ^
                  source.ts meta.block.ts switch-statement.expr.ts switch-block.expr.ts punctuation.terminator.statement.ts
 >	} 

--- a/tests/baselines/Issue427.baseline.txt
+++ b/tests/baselines/Issue427.baseline.txt
@@ -87,7 +87,7 @@ Grammar: TypeScript.tmLanguage
                                                                       ^
                                                                       source.ts meta.function.ts meta.block.ts
                                                                        ^^^^^
-                                                                       source.ts meta.function.ts meta.block.ts keyword.control.trycatch.ts
+                                                                       source.ts meta.function.ts meta.block.ts keyword.control.trycatch.flow.ts
                                                                             ^
                                                                             source.ts meta.function.ts meta.block.ts
                                                                              ^

--- a/tests/baselines/Issue610.baseline.txt
+++ b/tests/baselines/Issue610.baseline.txt
@@ -92,7 +92,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts
        ^^^^^
-       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts keyword.control.loop.ts
+       source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts keyword.control.loop.flow.ts
             ^
             source.ts meta.class.ts meta.method.declaration.ts meta.block.ts meta.block.ts
              ^^^^

--- a/tests/baselines/Issue65.baseline.txt
+++ b/tests/baselines/Issue65.baseline.txt
@@ -57,7 +57,7 @@ Grammar: TypeScript.tmLanguage
  ^^^^
  source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
      ^^^^^
-     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.ts
+     source.ts meta.class.ts meta.method.declaration.ts meta.block.ts keyword.control.trycatch.flow.ts
           ^
           source.ts meta.class.ts meta.method.declaration.ts meta.block.ts
            ^^^


### PR DESCRIPTION
I've been working on my own theme and I'd really like to be able to target `break`, `continue`, and `throw` separately from the rest of the `keyword.control.trycatch` and `keyword.control.loop` scopes.

I'd like to be able to highlight the `break`, `continue` and `throw` keywords separately as they all allow you to break out of the current flow of execution.

I'm not entirely sure of the best way to go about doing this, so I thought I'd open a speculative PR and see if I could get some feedback.

I've moved `break` and `continue` from the `keyword.control.loop` scope into `keyword.control.loop.flow`. I'm hoping this change avoids breaking existing themes while still giving us the ability to target these keywords separately.

For `throw` I've moved it from `keyword.control.trycatch` to `keyword.control.trycatch.flow`.

If I've gone completely off track here please let me know! I'm totally happy if these PR gets closed and there needs to be more discussion.