### PR TITLE
Consume leading docblock *s

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -2671,7 +2671,11 @@ repository:
       endCaptures:
         '0': { name: punctuation.definition.comment.ts }
       patterns:
-      - include: '#docblock'
+      - contentName: comment.block.documentation.body.ts
+        begin: (?<=/\*\*)([^*]|\*(?!/))*$
+        while: (^|\G)\s*\*(?!/)(?=([^*]|[*](?!/))*$)
+        patterns:
+        - include: '#docblock'
     - name: comment.block.ts
       begin: (/\*)(?:\s*((@)internal)(?=\s|(\*/)))?
       beginCaptures:
@@ -3078,9 +3082,6 @@ repository:
   jsdoctype:
   # {type}
     patterns:
-    # {unclosed
-    - name: invalid.illegal.type.jsdoc
-      match: \G{(?:[^}*]|\*[^/}])+$
     - contentName: entity.name.type.instance.jsdoc
       begin: \G({)
       beginCaptures:

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -8106,8 +8106,19 @@
             <key>patterns</key>
             <array>
               <dict>
-                <key>include</key>
-                <string>#docblock</string>
+                <key>contentName</key>
+                <string>comment.block.documentation.body.ts</string>
+                <key>begin</key>
+                <string>(?&lt;=/\*\*)([^*]|\*(?!/))*$</string>
+                <key>while</key>
+                <string>(^|\G)\s*\*(?!/)(?=([^*]|[*](?!/))*$)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#docblock</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -9046,12 +9057,6 @@
       <dict>
         <key>patterns</key>
         <array>
-          <dict>
-            <key>name</key>
-            <string>invalid.illegal.type.jsdoc</string>
-            <key>match</key>
-            <string>\G{(?:[^}*]|\*[^/}])+$</string>
-          </dict>
           <dict>
             <key>contentName</key>
             <string>entity.name.type.instance.jsdoc</string>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -8028,8 +8028,19 @@
             <key>patterns</key>
             <array>
               <dict>
-                <key>include</key>
-                <string>#docblock</string>
+                <key>contentName</key>
+                <string>comment.block.documentation.body.tsx</string>
+                <key>begin</key>
+                <string>(?&lt;=/\*\*)([^*]|\*(?!/))*$</string>
+                <key>while</key>
+                <string>(^|\G)\s*\*(?!/)(?=([^*]|[*](?!/))*$)</string>
+                <key>patterns</key>
+                <array>
+                  <dict>
+                    <key>include</key>
+                    <string>#docblock</string>
+                  </dict>
+                </array>
               </dict>
             </array>
           </dict>
@@ -8968,12 +8979,6 @@
       <dict>
         <key>patterns</key>
         <array>
-          <dict>
-            <key>name</key>
-            <string>invalid.illegal.type.jsdoc</string>
-            <key>match</key>
-            <string>\G{(?:[^}*]|\*[^/}])+$</string>
-          </dict>
           <dict>
             <key>contentName</key>
             <string>entity.name.type.instance.jsdoc</string>

--- a/tests/baselines/Issue153.baseline.txt
+++ b/tests/baselines/Issue153.baseline.txt
@@ -99,27 +99,35 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * A simple 3x3 matrix structure.
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * 
- ^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @export
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
 > * @class Matrix3x3
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^^^^^^^^^^^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts
@@ -319,53 +327,61 @@ Grammar: TypeScript.tmLanguage
      ^^^
      source.ts meta.class.ts comment.block.documentation.ts punctuation.definition.comment.ts
 >     * Gets a column as a new vector.
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * 
- ^^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * @param {number} index The index of the column (0 .. 2).
- ^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
         ^
-        source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+        source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
          ^^^^^
-         source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc
+         source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
               ^
-              source.ts meta.class.ts comment.block.documentation.ts
+              source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                ^
-               source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+               source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                 ^^^^^^
-                source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                       ^
-                      source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                      source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                        ^
-                       source.ts meta.class.ts comment.block.documentation.ts
+                       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                         ^^^^^
-                        source.ts meta.class.ts comment.block.documentation.ts variable.other.jsdoc
+                        source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                             source.ts meta.class.ts comment.block.documentation.ts
+                             source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * @returns {Vector3} A vector representing the column.
- ^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
         ^
-        source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+        source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
          ^^^^^^^
-         source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc
+         source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
                 ^
-                source.ts meta.class.ts comment.block.documentation.ts
+                source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                  ^
-                 source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+                 source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                   ^^^^^^^
-                  source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                  source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                          ^
-                         source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                         source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                           ^
-                          source.ts meta.class.ts comment.block.documentation.ts
+                          source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                            ^
-                           source.ts meta.class.ts comment.block.documentation.ts
+                           source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                            source.ts meta.class.ts comment.block.documentation.ts
+                            source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     */
  ^^^^^
  source.ts meta.class.ts comment.block.documentation.ts
@@ -697,53 +713,61 @@ Grammar: TypeScript.tmLanguage
      ^^^
      source.ts meta.class.ts comment.block.documentation.ts punctuation.definition.comment.ts
 >     * Gets a column as a new vector.
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * 
- ^^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * @param {number} index The index of the column (0 .. 2).
- ^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
         ^
-        source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+        source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
          ^^^^^
-         source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc
+         source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
               ^
-              source.ts meta.class.ts comment.block.documentation.ts
+              source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                ^
-               source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+               source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                 ^^^^^^
-                source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                       ^
-                      source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                      source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                        ^
-                       source.ts meta.class.ts comment.block.documentation.ts
+                       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                         ^^^^^
-                        source.ts meta.class.ts comment.block.documentation.ts variable.other.jsdoc
+                        source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                             source.ts meta.class.ts comment.block.documentation.ts
+                             source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * @returns {Vector3} A vector representing the column.
- ^^^^^^^
- source.ts meta.class.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^
+       source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
         ^
-        source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+        source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
          ^^^^^^^
-         source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc
+         source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
                 ^
-                source.ts meta.class.ts comment.block.documentation.ts
+                source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                  ^
-                 source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+                 source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                   ^^^^^^^
-                  source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                  source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                          ^
-                         source.ts meta.class.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                         source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                           ^
-                          source.ts meta.class.ts comment.block.documentation.ts
+                          source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                            ^
-                           source.ts meta.class.ts comment.block.documentation.ts
+                           source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                            source.ts meta.class.ts comment.block.documentation.ts
+                            source.ts meta.class.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     */
  ^^^^^
  source.ts meta.class.ts comment.block.documentation.ts

--- a/tests/baselines/Issue250.baseline.txt
+++ b/tests/baselines/Issue250.baseline.txt
@@ -64,14 +64,8 @@ Grammar: TypeScript.tmLanguage
  source.ts meta.class.ts
    ^^^
    source.ts meta.class.ts comment.block.documentation.ts punctuation.definition.comment.ts
-      ^
+      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
       source.ts meta.class.ts comment.block.documentation.ts
-       ^
-       source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
-        ^^^^^^^^
-        source.ts meta.class.ts comment.block.documentation.ts storage.type.class.jsdoc
-                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                source.ts meta.class.ts comment.block.documentation.ts
                                             ^^
                                             source.ts meta.class.ts comment.block.documentation.ts punctuation.definition.comment.ts
 >  static Original = function () {

--- a/tests/baselines/Issue276.baseline.txt
+++ b/tests/baselines/Issue276.baseline.txt
@@ -16,70 +16,76 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * @param {string} value
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                   ^
-                  source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                     ^^^^^
-                    source.ts comment.block.documentation.ts variable.other.jsdoc
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
 > * @param {string[]} arrayValue
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                   ^
-                  source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                     ^
-                    source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                      ^
-                     source.ts comment.block.documentation.ts
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                       ^^^^^^^^^^
-                      source.ts comment.block.documentation.ts variable.other.jsdoc
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
 > * @param {string} [optionalValue]
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                   ^
-                  source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                     ^
-                    source.ts comment.block.documentation.ts variable.other.jsdoc punctuation.definition.optional-value.begin.bracket.square.jsdoc
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc punctuation.definition.optional-value.begin.bracket.square.jsdoc
                      ^^^^^^^^^^^^^
-                     source.ts comment.block.documentation.ts variable.other.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                   ^
-                                  source.ts comment.block.documentation.ts variable.other.jsdoc punctuation.definition.optional-value.end.bracket.square.jsdoc
+                                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc punctuation.definition.optional-value.end.bracket.square.jsdoc
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/Issue37.baseline.txt
+++ b/tests/baselines/Issue37.baseline.txt
@@ -382,8 +382,10 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * Verify comments
- ^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/Issue387.baseline.txt
+++ b/tests/baselines/Issue387.baseline.txt
@@ -151,26 +151,40 @@ Grammar: TypeScript.tmLanguage
      ^^^
      source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 >     * Reads a string from the command line
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * ```
- ^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * async function main ( ) {
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     *    let name = await kary.terminal.input('Your name: ')
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     *    console.log(`Hello, ${ name }!`)
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * }
- ^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * ```
- ^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     */
  ^^^^^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/Issue435.baseline.txt
+++ b/tests/baselines/Issue435.baseline.txt
@@ -15,56 +15,64 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 >     * Manually add an item to the uploading queue.
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     *
- ^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * @param {PIXI.DisplayObject|PIXI.Container|PIXI.BaseTexture|PIXI.Texture|PIXI.Graphics|PIXI.Text|*} item - Object to
- ^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
         ^
-        source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+        source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
          ^^^^^
-         source.ts comment.block.documentation.ts storage.type.class.jsdoc
+         source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
               ^
-              source.ts comment.block.documentation.ts
+              source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                ^
-               source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+               source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                                                                                                          ^
-                                                                                                         source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                                                                                                         source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                                                                                                           ^
-                                                                                                          source.ts comment.block.documentation.ts
+                                                                                                          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                                                                                                            ^^^^
-                                                                                                           source.ts comment.block.documentation.ts variable.other.jsdoc
+                                                                                                           source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                                                                                                ^^^^^^^^^^^^^
-                                                                                                               source.ts comment.block.documentation.ts
+                                                                                                               source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     *        add to the queue
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^^^^^^^^^^^^^^^^^^^^^^^^^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     * @return {PIXI.CanvasPrepare} Instance of plugin for chaining.
- ^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^^^^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
         ^
-        source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+        source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
          ^^^^^^
-         source.ts comment.block.documentation.ts storage.type.class.jsdoc
+         source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
                ^
-               source.ts comment.block.documentation.ts
+               source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                 ^
-                source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+                source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                  ^^^^^^^^^^^^^^^^^^
-                 source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                 source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                                    ^
-                                   source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                                     ^
-                                    source.ts comment.block.documentation.ts
+                                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                                      ^^^^^^^^
-                                     source.ts comment.block.documentation.ts
+                                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                                              ^^^^^^^^^^^^^^^^^^^^^^^^^
-                                             source.ts comment.block.documentation.ts
+                                             source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >     */
  ^^^^^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/Issue445.baseline.txt
+++ b/tests/baselines/Issue445.baseline.txt
@@ -16,33 +16,37 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * My awesome function.
- ^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @param {{id: string, name: string}} object An object with an id and name field.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
              ^^^^^^^^^^^^^^^^^^^^^^^^
-             source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+             source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                                      ^
-                                     source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+                                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                                       ^
-                                      source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                                        ^
-                                       source.ts comment.block.documentation.ts
+                                       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                                         ^^^^^^
-                                        source.ts comment.block.documentation.ts variable.other.jsdoc
+                                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                              source.ts comment.block.documentation.ts
+                                              source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/Issue467.baseline.txt
+++ b/tests/baselines/Issue467.baseline.txt
@@ -1,0 +1,74 @@
+original file
+-----------------------------------
+/**
+ * @param {{
+ *  z: number
+ * }} x
+ */
+function foo(x) { }
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>/**
+ ^^^
+ source.ts comment.block.documentation.ts punctuation.definition.comment.ts
+> * @param {{
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+    ^
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+     ^^^^^
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
+          ^
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+           ^
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+            ^
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
+> *  z: number
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
+> * }} x
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
+    ^
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
+     ^
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+      ^
+      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+       ^
+       source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
+> */
+ ^
+ source.ts comment.block.documentation.ts
+  ^^
+  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
+>function foo(x) { }
+ ^^^^^^^^
+ source.ts meta.function.ts storage.type.function.ts
+         ^
+         source.ts meta.function.ts
+          ^^^
+          source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts
+             ^
+             source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+              ^
+              source.ts meta.function.ts meta.parameters.ts variable.parameter.ts
+               ^
+               source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                ^
+                source.ts meta.function.ts
+                 ^
+                 source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+                  ^
+                  source.ts meta.function.ts meta.block.ts
+                   ^
+                   source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts

--- a/tests/baselines/Issue515.baseline.txt
+++ b/tests/baselines/Issue515.baseline.txt
@@ -18,28 +18,30 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * @param {boolean} [settings.debug= - Print getUpdate results in console.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                     ^
-                    source.ts comment.block.documentation.ts
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                      ^
-                     source.ts comment.block.documentation.ts
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                       ^^^^^^^^^^^^^^
-                      source.ts comment.block.documentation.ts variable.other.jsdoc
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                    source.ts comment.block.documentation.ts
+                                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts
@@ -49,32 +51,34 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * @param {boolean} [settings.debug=] - Print getUpdate results in console.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                     ^
-                    source.ts comment.block.documentation.ts
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                      ^
-                     source.ts comment.block.documentation.ts variable.other.jsdoc punctuation.definition.optional-value.begin.bracket.square.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc punctuation.definition.optional-value.begin.bracket.square.jsdoc
                       ^^^^^^^^^^^^^^
-                      source.ts comment.block.documentation.ts variable.other.jsdoc
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                     ^
-                                    source.ts comment.block.documentation.ts variable.other.jsdoc keyword.operator.assignment.jsdoc
+                                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc keyword.operator.assignment.jsdoc
                                      ^
-                                     source.ts comment.block.documentation.ts variable.other.jsdoc punctuation.definition.optional-value.end.bracket.square.jsdoc
+                                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc punctuation.definition.optional-value.end.bracket.square.jsdoc
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                      source.ts comment.block.documentation.ts
+                                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts
@@ -84,34 +88,36 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * @param {boolean} [settings.debug=1] - Print getUpdate results in console.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                     ^
-                    source.ts comment.block.documentation.ts
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                      ^
-                     source.ts comment.block.documentation.ts variable.other.jsdoc punctuation.definition.optional-value.begin.bracket.square.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc punctuation.definition.optional-value.begin.bracket.square.jsdoc
                       ^^^^^^^^^^^^^^
-                      source.ts comment.block.documentation.ts variable.other.jsdoc
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                     ^
-                                    source.ts comment.block.documentation.ts variable.other.jsdoc keyword.operator.assignment.jsdoc
+                                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc keyword.operator.assignment.jsdoc
                                      ^
-                                     source.ts comment.block.documentation.ts variable.other.jsdoc source.embedded.ts
+                                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc source.embedded.ts
                                       ^
-                                      source.ts comment.block.documentation.ts variable.other.jsdoc punctuation.definition.optional-value.end.bracket.square.jsdoc
+                                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc punctuation.definition.optional-value.end.bracket.square.jsdoc
                                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                       source.ts comment.block.documentation.ts
+                                       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/Issue522.baseline.txt
+++ b/tests/baselines/Issue522.baseline.txt
@@ -87,8 +87,10 @@ Grammar: TypeScript.tmLanguage
    ^^^
    source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts comment.block.documentation.ts punctuation.definition.comment.ts
 >   * No TypeEror, but syntax highlighting is broken
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts comment.block.documentation.ts
+ ^^^^
+ source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts comment.block.documentation.ts comment.block.documentation.body.ts
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+     source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >   */
  ^^^
  source.ts meta.var.expr.ts meta.arrow.ts meta.block.ts comment.block.documentation.ts

--- a/tests/baselines/Issue688.baseline.txt
+++ b/tests/baselines/Issue688.baseline.txt
@@ -13,17 +13,21 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * @privateRemarks 
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^^^^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
                    ^^
-                   source.ts comment.block.documentation.ts
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * Bla bla bla.
- ^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/docComments.baseline.txt
+++ b/tests/baselines/docComments.baseline.txt
@@ -16,53 +16,61 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * This function takes two parameters
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @param {string} param1 Some string param.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                   ^
-                  source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                     ^^^^^^
-                    source.ts comment.block.documentation.ts variable.other.jsdoc
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                           ^^^^^^^^^^^^^^^^^^^^
-                          source.ts comment.block.documentation.ts
+                          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @param {number} param2  Some number param.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                   ^
-                  source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                     ^^^^^^
-                    source.ts comment.block.documentation.ts variable.other.jsdoc
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                           ^^^^^^^^^^^^^^^^^^^^^
-                          source.ts comment.block.documentation.ts
+                          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * some other contents
- ^^^^^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/jsdocProperty.baseline.txt
+++ b/tests/baselines/jsdocProperty.baseline.txt
@@ -35,117 +35,129 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * @namespace
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
 > * @property {object}  defaults               - The default values for parties.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
              ^
-             source.ts comment.block.documentation.ts
+             source.ts comment.block.documentation.ts comment.block.documentation.body.ts
               ^
-              source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+              source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                ^^^^^^
-               source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+               source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                      ^
-                     source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                       ^^
-                      source.ts comment.block.documentation.ts
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                         ^^^^^^^^
-                        source.ts comment.block.documentation.ts variable.other.jsdoc
+                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                source.ts comment.block.documentation.ts
+                                source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @property {number}  defaults.players       - The default number of players.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
              ^
-             source.ts comment.block.documentation.ts
+             source.ts comment.block.documentation.ts comment.block.documentation.body.ts
               ^
-              source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+              source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                ^^^^^^
-               source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+               source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                      ^
-                     source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                       ^^
-                      source.ts comment.block.documentation.ts
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                         ^^^^^^^^^^^^^^^^
-                        source.ts comment.block.documentation.ts variable.other.jsdoc
+                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                        source.ts comment.block.documentation.ts
+                                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @property {string}  defaults.level         - The default level for the party.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
              ^
-             source.ts comment.block.documentation.ts
+             source.ts comment.block.documentation.ts comment.block.documentation.body.ts
               ^
-              source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+              source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                ^^^^^^
-               source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+               source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                      ^
-                     source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                       ^^
-                      source.ts comment.block.documentation.ts
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                         ^^^^^^^^^^^^^^
-                        source.ts comment.block.documentation.ts variable.other.jsdoc
+                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                      source.ts comment.block.documentation.ts
+                                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @property {object}  defaults.treasure      - The default treasure.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
              ^
-             source.ts comment.block.documentation.ts
+             source.ts comment.block.documentation.ts comment.block.documentation.body.ts
               ^
-              source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+              source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                ^^^^^^
-               source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+               source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                      ^
-                     source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                       ^^
-                      source.ts comment.block.documentation.ts
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                         ^^^^^^^^^^^^^^^^^
-                        source.ts comment.block.documentation.ts variable.other.jsdoc
+                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                         source.ts comment.block.documentation.ts
+                                         source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @property {number}  defaults.treasure.gold - How much gold the party starts with.
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
              ^
-             source.ts comment.block.documentation.ts
+             source.ts comment.block.documentation.ts comment.block.documentation.body.ts
               ^
-              source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+              source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
                ^^^^^^
-               source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+               source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                      ^
-                     source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                     source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                       ^^
-                      source.ts comment.block.documentation.ts
+                      source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                         ^^^^^^^^^^^^^^^^^^^^^^
-                        source.ts comment.block.documentation.ts variable.other.jsdoc
+                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                                               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                                              source.ts comment.block.documentation.ts
+                                              source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts
@@ -248,56 +260,62 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * @class MyClass
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^^^^^^^^^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @param {string} name It is a Input Name
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
           ^
-          source.ts comment.block.documentation.ts
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts
            ^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
             ^^^^^^
-            source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+            source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                   ^
-                  source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                    ^
-                   source.ts comment.block.documentation.ts
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                     ^^^^
-                    source.ts comment.block.documentation.ts variable.other.jsdoc
+                    source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                         ^^^^^^^^^^^^^^^^^^^^
-                        source.ts comment.block.documentation.ts
+                        source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > * @prop {string} name It is a Prop Name
- ^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
     ^
-    source.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+    source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
      ^^^^
-     source.ts comment.block.documentation.ts storage.type.class.jsdoc
+     source.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
          ^
-         source.ts comment.block.documentation.ts
+         source.ts comment.block.documentation.ts comment.block.documentation.body.ts
           ^
-          source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
+          source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.begin.jsdoc
            ^^^^^^
-           source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc
+           source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc
                  ^
-                 source.ts comment.block.documentation.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
+                 source.ts comment.block.documentation.ts comment.block.documentation.body.ts entity.name.type.instance.jsdoc punctuation.definition.bracket.curly.end.jsdoc
                   ^
-                  source.ts comment.block.documentation.ts
+                  source.ts comment.block.documentation.ts comment.block.documentation.body.ts
                    ^^^^
-                   source.ts comment.block.documentation.ts variable.other.jsdoc
+                   source.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                        ^^^^^^^^^^^^^^^^^^^
-                       source.ts comment.block.documentation.ts
+                       source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/pr48_noSemiColon.baseline.txt
+++ b/tests/baselines/pr48_noSemiColon.baseline.txt
@@ -170,8 +170,10 @@ Grammar: TypeScript.tmLanguage
  ^^^
  source.ts comment.block.documentation.ts punctuation.definition.comment.ts
 > * Verify comments
- ^^^^^^^^^^^^^^^^^^^
- source.ts comment.block.documentation.ts
+ ^^
+ source.ts comment.block.documentation.ts comment.block.documentation.body.ts
+   ^^^^^^^^^^^^^^^^^
+   source.ts comment.block.documentation.ts comment.block.documentation.body.ts
 > */
  ^
  source.ts comment.block.documentation.ts

--- a/tests/baselines/typeparameterDefault.baseline.txt
+++ b/tests/baselines/typeparameterDefault.baseline.txt
@@ -41,43 +41,51 @@ Grammar: TypeScript.tmLanguage
         ^^
         source.ts meta.interface.ts comment.block.documentation.ts
 >      * Attaches callbacks for the resolution and/or rejection of the Promise. 
- ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
- source.ts meta.interface.ts comment.block.documentation.ts
+ ^^^^^^^
+ source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
+        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+        source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >      * @param onfulfilled The callback to execute when the Promise is resolved. 
- ^^^^^^^^
- source.ts meta.interface.ts comment.block.documentation.ts
+ ^^^^^^^
+ source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
+        ^
+        source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
          ^
-         source.ts meta.interface.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+         source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
           ^^^^^
-          source.ts meta.interface.ts comment.block.documentation.ts storage.type.class.jsdoc
+          source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
                ^
-               source.ts meta.interface.ts comment.block.documentation.ts
+               source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
                 ^^^^^^^^^^^
-                source.ts meta.interface.ts comment.block.documentation.ts variable.other.jsdoc
+                source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                           source.ts meta.interface.ts comment.block.documentation.ts
+                           source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >      * @param onrejected The callback to execute when the Promise is rejected.  
- ^^^^^^^^
- source.ts meta.interface.ts comment.block.documentation.ts
+ ^^^^^^^
+ source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
+        ^
+        source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
          ^
-         source.ts meta.interface.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+         source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
           ^^^^^
-          source.ts meta.interface.ts comment.block.documentation.ts storage.type.class.jsdoc
+          source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
                ^
-               source.ts meta.interface.ts comment.block.documentation.ts
+               source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
                 ^^^^^^^^^^
-                source.ts meta.interface.ts comment.block.documentation.ts variable.other.jsdoc
+                source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts variable.other.jsdoc
                           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                          source.ts meta.interface.ts comment.block.documentation.ts
+                          source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >      * @returns A Promise for the completion of which ever callback is executed.  
- ^^^^^^^^
- source.ts meta.interface.ts comment.block.documentation.ts
+ ^^^^^^^
+ source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
+        ^
+        source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
          ^
-         source.ts meta.interface.ts comment.block.documentation.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
+         source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc punctuation.definition.block.tag.jsdoc
           ^^^^^^^
-          source.ts meta.interface.ts comment.block.documentation.ts storage.type.class.jsdoc
+          source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts storage.type.class.jsdoc
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-                 source.ts meta.interface.ts comment.block.documentation.ts
+                 source.ts meta.interface.ts comment.block.documentation.ts comment.block.documentation.body.ts
 >      */
  ^^^^^^
  source.ts meta.interface.ts comment.block.documentation.ts

--- a/tests/cases/Issue467.ts
+++ b/tests/cases/Issue467.ts
@@ -1,0 +1,6 @@
+/**
+ * @param {{
+ *  z: number
+ * }} x
+ */
+function foo(x) { }


### PR DESCRIPTION
Fixes #467

- Adds a begin/while rule so that doc blocks also consume the leading *. This approach has been used by VS Code to support highlighting example blocks (see #693)

- Remove the `invalid.illegal.type.jsdoc` rule since we now can highlight multiline types better

Before:

<img width="268" alt="Screen Shot 2019-04-08 at 2 24 39 PM" src="https://user-images.githubusercontent.com/12821956/55757947-306af700-5a0a-11e9-9389-bd9289ef6464.png">

After:

<img width="229" alt="Screen Shot 2019-04-08 at 2 24 54 PM" src="https://user-images.githubusercontent.com/12821956/55757962-395bc880-5a0a-11e9-8f52-e0c21f7954a6.png">

