### PR TITLE
Fix an issue with coloring of the `this` parameter in parameter lists

### DIFF
--- a/TypeScript.YAML-tmTheme
+++ b/TypeScript.YAML-tmTheme
@@ -7,7 +7,7 @@ uuid: 91489F9C-F403-4CF0-993D-EAAF9149E40E
 settings:
 - scope: storage.modifier, storage.type, keyword.control, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression
   settings: { vsclassificationtype: keyword }
-- scope: support.type, constant.language, variable.language
+- scope: support.type, constant.language, variable.language, variable.language variable.parameter
   settings: { vsclassificationtype: keyword }
 
 - scope: string, punctuation.definition.string, constant.character

--- a/TypeScript.tmTheme
+++ b/TypeScript.tmTheme
@@ -19,7 +19,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>support.type, constant.language, variable.language</string>
+        <string>support.type, constant.language, variable.language, variable.language variable.parameter</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -19,7 +19,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>support.type, constant.language, variable.language</string>
+        <string>support.type, constant.language, variable.language, variable.language variable.parameter</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>


### PR DESCRIPTION
In Visual Studio, there is an issue with coloring of the `this` parameter when it is in a parameter list. Specifically:
```
function bar(this: void) {
}

function baz(this: void) {

}
```

the first `this` is colored as a keyword and the second `this` is colored as an identifier. The reason is that its scopes include both variable.language.this.ts and varuable.parameter.ts. In the theme, the first scope is matched to a keyword and the second one is matched to an identifier. So the resulting classification becomes implementation dependent and the implementation turns out to produce either of the 2 options randomly. This PR explicitly classifies the combined scopes as a keyword.

Another example follows, where the second `this` is classified as an identifier:
```
type t1 = (this: void) => void;
type t2 = (this: void
) => void;
```