### PR TITLE
Note that jsdoc grammar is unmaintained upstream

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -2732,6 +2732,7 @@ repository:
       - include: '#string'
 
   #jsdoc syntax taken from https://github.com/atom/language-javascript/
+  #no longer maintained there, however: https://github.com/atom/language-javascript/pull/645#issuecomment-496795093
   docblock:
     patterns:
     # @access private|protected|public


### PR DESCRIPTION
They're using tree-sitter now, and don't want tmLanguage patches anymore.

(See https://github.com/atom/language-javascript/pull/645#issuecomment-496795093.)