### PR TITLE
Use 'contentName' instead of 'name' to mark embedded jsx expressions

### DIFF
--- a/TypeScriptReact.YAML-tmLanguage
+++ b/TypeScriptReact.YAML-tmLanguage
@@ -130,7 +130,7 @@ repository:
 
   #entities and evaluated code
   jsx-evaluated-code:
-    name: meta.embedded.expression.tsx
+    contentName: meta.embedded.expression.tsx
     begin: \{
     end: \}
     beginCaptures:

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -9397,7 +9397,7 @@
       </dict>
       <key>jsx-evaluated-code</key>
       <dict>
-        <key>name</key>
+        <key>contentName</key>
         <string>meta.embedded.expression.tsx</string>
         <key>begin</key>
         <string>\{</string>

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,9 +20,9 @@
       "integrity": "sha512-NYrtPht0wGzhwe9+/idPaBB+TqkY9AhTvOLMkThm0IoEfLaiVQZwBwyJ5puCkO3AUCWrmcoePjp2mbFocKy4SQ=="
     },
     "@types/node": {
-      "version": "12.6.2",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.6.2.tgz",
-      "integrity": "sha512-gojym4tX0FWeV2gsW4Xmzo5wxGjXGm550oVUII7f7G5o4BV6c7DBdiG1RRQd+y1bvqRyYtPfMK85UM95vsapqQ=="
+      "version": "12.7.12",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.7.12.tgz",
+      "integrity": "sha512-KPYGmfD0/b1eXurQ59fXD1GBzhSQfz6/lKBxkaHX9dKTzjXbK68Zt7yGUxUsCS1jeTy/8aL+d9JEr+S54mpkWQ=="
     },
     "ansi-colors": {
       "version": "3.2.3",
@@ -123,19 +123,39 @@
       "integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
     },
     "cliui": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
-      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-5.0.0.tgz",
+      "integrity": "sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==",
       "requires": {
-        "string-width": "^2.1.1",
-        "strip-ansi": "^4.0.0",
-        "wrap-ansi": "^2.0.0"
+        "string-width": "^3.1.0",
+        "strip-ansi": "^5.2.0",
+        "wrap-ansi": "^5.1.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
       }
-    },
-    "code-point-at": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "color-convert": {
       "version": "1.9.3",
@@ -268,6 +288,7 @@
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
       "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
       "requires": {
         "nice-try": "^1.0.4",
         "path-key": "^2.0.1",
@@ -319,21 +340,26 @@
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
       "integrity": "sha512-1MkrZNvWTKCaigbn+W15elq2BB/L22nqrSY5DKlo3X6+vclJm8Bb5djXJBmEX6fS3+zCh/F4VBK5Z2KxJt4s2Q==",
+      "dev": true,
       "requires": {
         "once": "^1.4.0"
       }
     },
     "es-abstract": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.13.0.tgz",
-      "integrity": "sha512-vDZfg/ykNxQVwup/8E1BZhVzFfBxs9NqMzGcvIJrqg5k2/5Za2bWo40dK2J1pgLngZ7c+Shh8lwYtLGyrwPutg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.15.0.tgz",
+      "integrity": "sha512-bhkEqWJ2t2lMeaJDuk7okMkJWI/yqgH/EoGwpcvv0XW9RWQsRspI4wt6xuyuvMvvQE3gg/D9HXppgk21w78GyQ==",
       "requires": {
         "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
+        "has-symbols": "^1.0.0",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-keys": "^1.0.12"
+        "object-inspect": "^1.6.0",
+        "object-keys": "^1.1.1",
+        "string.prototype.trimleft": "^2.1.0",
+        "string.prototype.trimright": "^2.1.0"
       }
     },
     "es-to-primitive": {
@@ -360,6 +386,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
       "integrity": "sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==",
+      "dev": true,
       "requires": {
         "cross-spawn": "^6.0.0",
         "get-stream": "^4.0.0",
@@ -410,6 +437,7 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
       "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -472,12 +500,13 @@
     "invert-kv": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+      "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA==",
+      "dev": true
     },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-callable": {
       "version": "1.1.4",
@@ -505,7 +534,8 @@
     "is-stream": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
-      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ=",
+      "dev": true
     },
     "is-symbol": {
       "version": "1.0.2",
@@ -545,6 +575,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
       "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
+      "dev": true,
       "requires": {
         "invert-kv": "^2.0.0"
       }
@@ -561,7 +592,8 @@
     "lodash": {
       "version": "4.17.13",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.13.tgz",
-      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA=="
+      "integrity": "sha512-vm3/XWXfWtRua0FkUyEHBZy8kCPjErNBT9fJx8Zvs+U6zjqPbTUOpkaoum3O5uiA8sm+yNMHXfYkTUHFoMxFNA==",
+      "dev": true
     },
     "log-symbols": {
       "version": "2.2.0",
@@ -575,6 +607,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/map-age-cleaner/-/map-age-cleaner-0.1.3.tgz",
       "integrity": "sha512-bJzx6nMoP6PDLPBFmg7+xRKeFZvFboMrGlxmNj9ClvX53KrmvM5bXFXEWjbz4cz1AFn+jWJ9z/DJSz7hrs0w3w==",
+      "dev": true,
       "requires": {
         "p-defer": "^1.0.0"
       }
@@ -583,6 +616,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-4.3.0.tgz",
       "integrity": "sha512-qX2bG48pTqYRVmDB37rn/6PT7LcR8T7oAX3bf99u1Tt1nzxYfxkgqDwUwolPlXweM0XzBOBFzSx4kfp7KP1s/w==",
+      "dev": true,
       "requires": {
         "map-age-cleaner": "^0.1.1",
         "mimic-fn": "^2.0.0",
@@ -592,7 +626,8 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "dev": true
     },
     "minimatch": {
       "version": "3.0.4",
@@ -616,9 +651,9 @@
       }
     },
     "mocha": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.1.4.tgz",
-      "integrity": "sha512-PN8CIy4RXsIoxoFJzS4QNnCH4psUCPWc4/rPrst/ecSJJbLBkubMiyGCP2Kj/9YnWbotFqAoeXyXMucj7gwCFg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-6.2.1.tgz",
+      "integrity": "sha512-VCcWkLHwk79NYQc8cxhkmI8IigTIhsCwZ6RTxQsqK6go4UvEhzJkYuHm8B2YtlSxcYq2fY+ucr4JBwoD6ci80A==",
       "requires": {
         "ansi-colors": "3.2.3",
         "browser-stdout": "1.3.1",
@@ -640,9 +675,9 @@
         "supports-color": "6.0.0",
         "which": "1.3.1",
         "wide-align": "1.1.3",
-        "yargs": "13.2.2",
-        "yargs-parser": "13.0.0",
-        "yargs-unparser": "1.5.0"
+        "yargs": "13.3.0",
+        "yargs-parser": "13.1.1",
+        "yargs-unparser": "1.6.0"
       }
     },
     "mocha-multi-reporters": {
@@ -668,7 +703,8 @@
     "nice-try": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
-      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ=="
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
     },
     "node-environment-flags": {
       "version": "1.0.5",
@@ -693,14 +729,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "dev": true,
       "requires": {
         "path-key": "^2.0.0"
       }
     },
-    "number-is-nan": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+    "object-inspect": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.6.0.tgz",
+      "integrity": "sha512-GJzfBZ6DgDAmnuaM3104jR4s1Myxr3Y3zfIyN4z3UdqN69oSRacNK8UhnobDdC+7J2AHCjGwxQubNJfE70SXXQ=="
     },
     "object-keys": {
       "version": "1.1.1",
@@ -747,6 +784,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-3.1.0.tgz",
       "integrity": "sha512-Z8l3R4wYWM40/52Z+S265okfFj8Kt2cC2MKY+xNi3kFs+XGI7WXu/I309QQQYbRW4ijiZ+yxs9pqEhJh0DqW3Q==",
+      "dev": true,
       "requires": {
         "execa": "^1.0.0",
         "lcid": "^2.0.0",
@@ -756,17 +794,20 @@
     "p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
-      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww="
+      "integrity": "sha1-n26xgvbJqozXQwBKfU+WsZaw+ww=",
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
-      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
+      "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=",
+      "dev": true
     },
     "p-is-promise": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-2.1.0.tgz",
-      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg=="
+      "integrity": "sha512-Y3W0wlRPK8ZMRbNq97l4M5otioeA5lm1z7bkNkxCka8HSPjR0xRWmpCmc9utiaLP9Jb1eD8BgeIxTW4AIF45Pg==",
+      "dev": true
     },
     "p-limit": {
       "version": "2.2.0",
@@ -802,7 +843,8 @@
     "path-key": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
-      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
     },
     "pathval": {
       "version": "1.1.0",
@@ -829,6 +871,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
       "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "dev": true,
       "requires": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"
@@ -876,6 +919,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
       "requires": {
         "shebang-regex": "^1.0.0"
       }
@@ -883,12 +927,14 @@
     "shebang-regex": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
-      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM="
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
     },
     "signal-exit": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
-      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",
@@ -902,6 +948,24 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
+      }
+    },
+    "string.prototype.trimleft": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
+      "integrity": "sha512-FJ6b7EgdKxxbDxc79cOlok6Afd++TTs5szo+zJTUyow3ycrRfJVE2pq3vcN53XexvKZu/DJMDfeI/qMiZTrjTw==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
+      }
+    },
+    "string.prototype.trimright": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.0.tgz",
+      "integrity": "sha512-fXZTSV55dNBwv16uw+hh5jkghxSnc5oHq+5K/gXgizHwAvMetdAJlHqqoFC1FSDVPYWLkAKl2cxpUT41sV7nSg==",
+      "requires": {
+        "define-properties": "^1.1.3",
+        "function-bind": "^1.1.1"
       }
     },
     "string_decoder": {
@@ -921,7 +985,8 @@
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
-      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
+      "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=",
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -984,9 +1049,9 @@
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g=="
     },
     "typescript": {
-      "version": "3.5.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
-      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+      "version": "3.6.4",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.6.4.tgz",
+      "integrity": "sha512-unoCll1+l+YK4i4F8f22TaNVPRHcD9PA3yCuZ8g5e0qGqlVlJ/8FSateOLLSagn+Yg5+ZwuPkL8LFUc0Jcvksg=="
     },
     "util-deprecate": {
       "version": "1.0.2",
@@ -1024,43 +1089,36 @@
       }
     },
     "wrap-ansi": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
-      "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+      "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
       "requires": {
-        "string-width": "^1.0.1",
-        "strip-ansi": "^3.0.1"
+        "ansi-styles": "^3.2.0",
+        "string-width": "^3.0.0",
+        "strip-ansi": "^5.0.0"
       },
       "dependencies": {
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
         },
         "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "requires": {
-            "code-point-at": "^1.0.0",
-            "is-fullwidth-code-point": "^1.0.0",
-            "strip-ansi": "^3.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
           }
         },
         "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
           "requires": {
-            "ansi-regex": "^2.0.0"
+            "ansi-regex": "^4.1.0"
           }
         }
       }
@@ -1092,21 +1150,20 @@
       "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yargs": {
-      "version": "13.2.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.2.2.tgz",
-      "integrity": "sha512-WyEoxgyTD3w5XRpAQNYUB9ycVH/PQrToaTXdYXRdOXvEy1l19br+VJsc0vcO8PTGg5ro/l/GY7F/JMEBmI0BxA==",
+      "version": "13.3.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-13.3.0.tgz",
+      "integrity": "sha512-2eehun/8ALW8TLoIl7MVaRUrg+yCnenu8B4kBlRxj3GJGDKU1Og7sMXPNm1BYyM1DOJmTZ4YeN/Nwxv+8XJsUA==",
       "requires": {
-        "cliui": "^4.0.0",
+        "cliui": "^5.0.0",
         "find-up": "^3.0.0",
         "get-caller-file": "^2.0.1",
-        "os-locale": "^3.1.0",
         "require-directory": "^2.1.1",
         "require-main-filename": "^2.0.0",
         "set-blocking": "^2.0.0",
         "string-width": "^3.0.0",
         "which-module": "^2.0.0",
         "y18n": "^4.0.0",
-        "yargs-parser": "^13.0.0"
+        "yargs-parser": "^13.1.1"
       },
       "dependencies": {
         "ansi-regex": {
@@ -1135,61 +1192,28 @@
       }
     },
     "yargs-parser": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.0.0.tgz",
-      "integrity": "sha512-w2LXjoL8oRdRQN+hOyppuXs+V/fVAYtpcrRxZuF7Kt/Oc+Jr2uAcVntaUTNT6w5ihoWfFDpNY8CPx1QskxZ/pw==",
+      "version": "13.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-13.1.1.tgz",
+      "integrity": "sha512-oVAVsHz6uFrg3XQheFII8ESO2ssAf9luWuAd6Wexsu4F3OtIW0o8IribPXYrD4WC24LWtPrJlGy87y5udK+dxQ==",
       "requires": {
         "camelcase": "^5.0.0",
         "decamelize": "^1.2.0"
       }
     },
     "yargs-unparser": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.5.0.tgz",
-      "integrity": "sha512-HK25qidFTCVuj/D1VfNiEndpLIeJN78aqgR23nL3y4N0U/91cOAzqfHlF8n2BvoNDcZmJKin3ddNSvOxSr8flw==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/yargs-unparser/-/yargs-unparser-1.6.0.tgz",
+      "integrity": "sha512-W9tKgmSn0DpSatfri0nx52Joq5hVXgeLiqR/5G0sZNDoLZFOr/xjBUDcShCOGNsBnEMNo1KAMBkTej1Hm62HTw==",
       "requires": {
         "flat": "^4.1.0",
-        "lodash": "^4.17.11",
-        "yargs": "^12.0.5"
+        "lodash": "^4.17.15",
+        "yargs": "^13.3.0"
       },
       "dependencies": {
-        "get-caller-file": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
-          "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
-        },
-        "require-main-filename": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
-          "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
-        },
-        "yargs": {
-          "version": "12.0.5",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.5.tgz",
-          "integrity": "sha512-Lhz8TLaYnxq/2ObqHDql8dX8CJi97oHxrjUcYtzKbbykPtVW9WB+poxI+NM2UIzsMgNCZTIf0AQwsjK5yMAqZw==",
-          "requires": {
-            "cliui": "^4.0.0",
-            "decamelize": "^1.2.0",
-            "find-up": "^3.0.0",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^3.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1 || ^4.0.0",
-            "yargs-parser": "^11.1.1"
-          }
-        },
-        "yargs-parser": {
-          "version": "11.1.1",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-11.1.1.tgz",
-          "integrity": "sha512-C6kB/WJDiaxONLJQnF8ccx9SEeoTTLek8RVbaOIsrAUS8VrBEXfmeSnCZxygc+XC2sNMBIwOOnfcxiynjHsVSQ==",
-          "requires": {
-            "camelcase": "^5.0.0",
-            "decamelize": "^1.2.0"
-          }
+        "lodash": {
+          "version": "4.17.15",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+          "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         }
       }
     }

--- a/tests/baselines/Issue280.baseline.txt
+++ b/tests/baselines/Issue280.baseline.txt
@@ -223,7 +223,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
      ^
-     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
 >      this.props.forecasts.map(forecast => {
  ^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
@@ -320,7 +320,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx
      ^
-     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 >    </tbody>
  ^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx

--- a/tests/baselines/Issue357.baseline.txt
+++ b/tests/baselines/Issue357.baseline.txt
@@ -137,7 +137,7 @@ Grammar: TypeScriptReact.tmLanguage
                 ^
                 source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                  ^
-                 source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                 source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                   ^^^^^^
                   source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.object.tsx
                         ^
@@ -145,7 +145,7 @@ Grammar: TypeScriptReact.tmLanguage
                          ^^^^^^
                          source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                ^
-                               source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                               source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
 >      itemProp='offers'
  ^^^^^^
  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx
@@ -217,7 +217,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^^^^^^^
  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+         source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
           ^^^^^^^
           source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
 >          ? I18n.toCurrency(price)
@@ -257,7 +257,7 @@ Grammar: TypeScriptReact.tmLanguage
                            ^
                            source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                             ^
-                            source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                            source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                              ^^^^^^
                              source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.object.tsx
                                    ^
@@ -265,14 +265,14 @@ Grammar: TypeScriptReact.tmLanguage
                                     ^^^^^^^^^^
                                     source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                               ^
-                                              source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                              source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                                ^
                                                source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >                      {`${dash}`}{I18n.t('spree.out_of_stock')}{`${dash}`}
  ^^^^^^^^^^^^^^^^^^^^^^
  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx
                        ^
-                       source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                       source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                         ^
                         source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.template.tsx punctuation.definition.string.template.begin.tsx
                          ^^
@@ -284,9 +284,9 @@ Grammar: TypeScriptReact.tmLanguage
                                 ^
                                 source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.template.tsx punctuation.definition.string.template.end.tsx
                                  ^
-                                 source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                 source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
                                   ^
-                                  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                                    ^^^^
                                    source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.function-call.tsx variable.other.object.tsx
                                        ^
@@ -304,9 +304,9 @@ Grammar: TypeScriptReact.tmLanguage
                                                               ^
                                                               source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
                                                                ^
-                                                               source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                               source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
                                                                 ^
-                                                                source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                                                source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                                                                  ^
                                                                  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.template.tsx punctuation.definition.string.template.begin.tsx
                                                                   ^^
@@ -318,7 +318,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                                          ^
                                                                          source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.template.tsx punctuation.definition.string.template.end.tsx
                                                                           ^
-                                                                          source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                          source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 >            </div>}
  ^^^^^^^^^^^^
  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx meta.jsx.children.tsx
@@ -329,7 +329,7 @@ Grammar: TypeScriptReact.tmLanguage
                   ^
                   source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
                    ^
-                   source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                   source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 >      </span>
  ^^^^^^
  source.tsx meta.var.expr.tsx meta.arrow.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.tag.tsx meta.jsx.children.tsx

--- a/tests/baselines/Issue430.baseline.txt
+++ b/tests/baselines/Issue430.baseline.txt
@@ -158,18 +158,18 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
               ^
-              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                ^^^
                source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                   ^
-                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                    ^
                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >        {weekDay.label} {this.props.data[weekDay.id].start} - {this.props.data[weekDay.id].finish}
  ^^^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
           ^^^^^^^
           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.object.tsx
                  ^
@@ -177,11 +177,11 @@ Grammar: TypeScriptReact.tmLanguage
                   ^^^^^
                   source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.variable.property.dom.tsx
                        ^
-                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
                         ^
                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx
                          ^
-                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                           ^^^^
                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.language.this.tsx
                               ^
@@ -207,11 +207,11 @@ Grammar: TypeScriptReact.tmLanguage
                                                       ^^^^^
                                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx support.variable.property.dom.tsx
                                                            ^
-                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
                                                             ^^^
                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx
                                                                ^
-                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                                                                 ^^^^
                                                                 source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.language.this.tsx
                                                                     ^
@@ -237,7 +237,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                                                             ^^^^^^
                                                                                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                                                                                   ^
-                                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                                                  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 >      </p>
  ^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.arrow.tsx meta.tag.tsx meta.jsx.children.tsx

--- a/tests/baselines/Issue461.baseline.txt
+++ b/tests/baselines/Issue461.baseline.txt
@@ -66,7 +66,7 @@ Grammar: TypeScriptReact.tmLanguage
                  ^
                  source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                   ^
-                  source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                  source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                    ^^^^
                    source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.language.this.tsx
                        ^
@@ -78,7 +78,7 @@ Grammar: TypeScriptReact.tmLanguage
                               ^^^^^^^^^
                               source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx support.variable.property.dom.tsx
                                        ^
-                                       source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                       source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                         ^
                                         source.tsx meta.class.tsx meta.field.declaration.tsx meta.arrow.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
                                          ^
@@ -130,7 +130,7 @@ Grammar: TypeScriptReact.tmLanguage
                      ^
                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                       ^
-                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                      source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                        ^^^^
                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.language.this.tsx
                            ^
@@ -164,14 +164,14 @@ Grammar: TypeScriptReact.tmLanguage
                                                        ^^^^^^^^^^^^^^^^^
                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                                                         ^
-                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                        source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                                                          ^
                                                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >        {!this.state.loaded && this.renderProgress()}
  ^^^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
           ^
           source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx keyword.operator.logical.tsx
            ^^^^
@@ -201,7 +201,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                     ^
                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.brace.round.tsx
                                                      ^
-                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                     source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 >      </div>
  ^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx

--- a/tests/baselines/Issue518.baseline.txt
+++ b/tests/baselines/Issue518.baseline.txt
@@ -25,7 +25,7 @@ Grammar: TypeScriptReact.tmLanguage
           ^
           source.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
            ^
-           source.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+           source.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
             ^
             source.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
              ^
@@ -127,7 +127,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                                                                  ^
                                                                                                  source.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx
                                                                                                   ^
-                                                                                                  source.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                                                  source.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                                                                                    ^
                                                                                                    source.tsx meta.tag.tsx meta.tag.attributes.tsx
                                                                                                     ^^

--- a/tests/baselines/Issue624.baseline.txt
+++ b/tests/baselines/Issue624.baseline.txt
@@ -46,7 +46,7 @@ Grammar: TypeScriptReact.tmLanguage
                  ^
                  source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                   ^
-                  source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                  source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                    ^
                    source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx string.template.tsx punctuation.definition.string.template.begin.tsx
                     ^^^^
@@ -64,7 +64,7 @@ Grammar: TypeScriptReact.tmLanguage
                                  ^
                                  source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx string.template.tsx punctuation.definition.string.template.end.tsx
                                   ^
-                                  source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                  source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                    ^
                                    source.tsx meta.arrow.tsx meta.array.literal.tsx meta.tag.tsx meta.tag.attributes.tsx
                                     ^^

--- a/tests/baselines/Issue632.baseline.txt
+++ b/tests/baselines/Issue632.baseline.txt
@@ -48,7 +48,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
    ^
-   source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+   source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
     ^
     source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.parameters.tsx punctuation.definition.parameters.begin.tsx
      ^
@@ -92,11 +92,11 @@ Grammar: TypeScriptReact.tmLanguage
            ^
            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
             ^
-            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
              ^^^^
              source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                  ^
-                 source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                 source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
 >      variants={['TEST']}
  ^^^^^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx
@@ -105,7 +105,7 @@ Grammar: TypeScriptReact.tmLanguage
                ^
                source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                 ^
-                source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                  ^
                  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                   ^
@@ -117,7 +117,7 @@ Grammar: TypeScriptReact.tmLanguage
                         ^
                         source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                          ^
-                         source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                         source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
 >    />
  ^^^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx
@@ -129,7 +129,7 @@ Grammar: TypeScriptReact.tmLanguage
    ^
    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.brace.round.tsx
     ^
-    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 ></Bar>
  ^^
  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
@@ -151,7 +151,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
    ^
-   source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+   source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
     ^
     source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.parameters.tsx punctuation.definition.parameters.begin.tsx
      ^
@@ -198,11 +198,11 @@ Grammar: TypeScriptReact.tmLanguage
            ^
            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
             ^
-            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
              ^^^^
              source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                  ^
-                 source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                 source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
 >    />
  ^^^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx
@@ -214,7 +214,7 @@ Grammar: TypeScriptReact.tmLanguage
    ^
    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.brace.round.tsx
     ^
-    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 ></Bar>
  ^^
  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
@@ -236,7 +236,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
    ^
-   source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+   source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
     ^
     source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.parameters.tsx punctuation.definition.parameters.begin.tsx
      ^
@@ -283,11 +283,11 @@ Grammar: TypeScriptReact.tmLanguage
            ^
            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
             ^
-            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+            source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
              ^^^^
              source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                  ^
-                 source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                 source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
 >      variants={['TEST']}
  ^^^^^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx
@@ -296,7 +296,7 @@ Grammar: TypeScriptReact.tmLanguage
                ^
                source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                 ^
-                source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                  ^
                  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                   ^
@@ -308,7 +308,7 @@ Grammar: TypeScriptReact.tmLanguage
                         ^
                         source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                          ^
-                         source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                         source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
 >    />
  ^^^^
  source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.tag.tsx meta.tag.attributes.tsx
@@ -320,7 +320,7 @@ Grammar: TypeScriptReact.tmLanguage
    ^
    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.brace.round.tsx
     ^
-    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+    source.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 ></Bar>
  ^^
  source.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx

--- a/tests/baselines/Issue667.baseline.txt
+++ b/tests/baselines/Issue667.baseline.txt
@@ -35,7 +35,7 @@ Grammar: TypeScriptReact.tmLanguage
                           ^
                           source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                            ^
-                           source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                           source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                             ^^^^^^
                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.object.tsx
                                   ^
@@ -79,7 +79,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                                          ^
                                                                          source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                                           ^
-                                                                          source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                          source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                                                            ^
                                                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx
                                                                             ^^^^^^^^^^^^^^^^
@@ -87,7 +87,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                                                             ^
                                                                                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                                                                                              ^
-                                                                                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                                                                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                                                                                               ^
                                                                                               source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.parameters.tsx punctuation.definition.parameters.begin.tsx
                                                                                                ^^^^^
@@ -107,7 +107,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                                                                            ^
                                                                                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.arrow.tsx meta.block.tsx punctuation.definition.block.tsx
                                                                                                             ^
-                                                                                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                                                                                              ^
                                                                                                              source.tsx meta.var.expr.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
                                                                                                               ^^^^

--- a/tests/baselines/TsxSamples.baseline.txt
+++ b/tests/baselines/TsxSamples.baseline.txt
@@ -127,7 +127,7 @@ Grammar: TypeScriptReact.tmLanguage
                             ^
                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                              ^
-                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                               ^^^^
                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.language.this.tsx
                                   ^
@@ -135,14 +135,14 @@ Grammar: TypeScriptReact.tmLanguage
                                    ^^^^
                                    source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                        ^
-                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                       source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                         ^
                                         source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx punctuation.definition.tag.end.tsx
 >            This is a test: {this.state.count}
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
                              ^
-                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                             source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                               ^^^^
                               source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.language.this.tsx
                                   ^
@@ -154,7 +154,7 @@ Grammar: TypeScriptReact.tmLanguage
                                          ^^^^^
                                          source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx variable.other.property.tsx
                                               ^
-                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                              source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 >        </div>
  ^^^^^^^^
  source.tsx meta.class.tsx meta.method.declaration.tsx meta.block.tsx meta.tag.tsx meta.jsx.children.tsx
@@ -412,7 +412,7 @@ Grammar: TypeScriptReact.tmLanguage
  ^^^^^^^^
  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
          ^
-         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+         source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
           ^^
           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -420,7 +420,7 @@ Grammar: TypeScriptReact.tmLanguage
                                           ^^
                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx comment.block.tsx punctuation.definition.comment.tsx
                                             ^
-                                            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                            source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
 >        <Person name={window.isLoggedIn ? window.name : ''}
  ^^^^^^^^
  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx
@@ -435,7 +435,7 @@ Grammar: TypeScriptReact.tmLanguage
                      ^
                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                       ^
-                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                        ^^^^^^
                        source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx support.variable.dom.tsx
                              ^
@@ -465,7 +465,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                           ^
                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                            ^
-                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
 >        />
  ^^^^^^^^
  source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.tag.tsx meta.tag.attributes.tsx
@@ -571,13 +571,13 @@ Grammar: TypeScriptReact.tmLanguage
                            ^
                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx
                             ^
-                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                              ^^^
                              source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx
                                 ^^^^^
                                 source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                                      ^
-                                     source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                     source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                       ^
                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx
                                        ^^
@@ -640,13 +640,13 @@ Grammar: TypeScriptReact.tmLanguage
                             ^
                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx
                              ^
-                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                             source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                               ^^^
                               source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx keyword.operator.spread.tsx
                                  ^^^^^
                                  source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx variable.other.readwrite.tsx
                                       ^
-                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                        ^
                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx
                                         ^^^
@@ -654,7 +654,7 @@ Grammar: TypeScriptReact.tmLanguage
                                            ^
                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                                             ^
-                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                            source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                                              ^
                                              source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                                               ^^^^^^^^
@@ -662,7 +662,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                       ^
                                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                        ^
-                                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                       source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                                         ^
                                                         source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx
                                                          ^^
@@ -700,7 +700,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                ^
                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                 ^^^^^^
@@ -712,7 +712,7 @@ Grammar: TypeScriptReact.tmLanguage
                                    ^
                                    source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                     ^
-                                    source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                    source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
                                      ^^
                                      source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                        ^^^
@@ -739,7 +739,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                ^
                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.begin.tsx
                 ^^^^^^
@@ -777,7 +777,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                              ^
                                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx string.quoted.single.tsx punctuation.definition.string.end.tsx
                                                               ^
-                                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
                                                                ^^
                                                                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                                  ^^^
@@ -804,7 +804,7 @@ Grammar: TypeScriptReact.tmLanguage
              ^
              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.end.tsx
               ^
-              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+              source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.begin.tsx
                ^
                source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                 ^
@@ -848,7 +848,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                           ^
                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx meta.array.literal.tsx meta.brace.square.tsx
                                                            ^
-                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                           source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx meta.jsx.children.tsx punctuation.section.embedded.end.tsx
                                                             ^^
                                                             source.tsx meta.var.expr.tsx meta.tag.without-attributes.tsx punctuation.definition.tag.begin.tsx
                                                               ^^^
@@ -879,7 +879,7 @@ Grammar: TypeScriptReact.tmLanguage
                                      ^
                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                                       ^
-                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                                      source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                                        ^
                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.objectliteral.tsx punctuation.definition.block.tsx
                                         ^^^^^^
@@ -897,7 +897,7 @@ Grammar: TypeScriptReact.tmLanguage
                                                                        ^
                                                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx meta.objectliteral.tsx punctuation.definition.block.tsx
                                                                         ^
-                                                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                                                                        source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                                                          ^
                                                                          source.tsx meta.var.expr.tsx meta.tag.tsx meta.tag.attributes.tsx
                                                                           ^^

--- a/tests/baselines/jsxTagWithTypeArguments.baseline.txt
+++ b/tests/baselines/jsxTagWithTypeArguments.baseline.txt
@@ -29,11 +29,11 @@ Grammar: TypeScriptReact.tmLanguage
                           ^
                           source.tsx meta.tag.tsx meta.tag.attributes.tsx keyword.operator.assignment.tsx
                            ^
-                           source.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.begin.tsx
+                           source.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.begin.tsx
                             ^^
                             source.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx constant.numeric.decimal.tsx
                               ^
-                              source.tsx meta.tag.tsx meta.tag.attributes.tsx meta.embedded.expression.tsx punctuation.section.embedded.end.tsx
+                              source.tsx meta.tag.tsx meta.tag.attributes.tsx punctuation.section.embedded.end.tsx
                                ^
                                source.tsx meta.tag.tsx meta.tag.attributes.tsx
                                 ^^


### PR DESCRIPTION
Jsx expressions currently use `name` to mark the entire expresion (including the opening and closing braces) as `meta.embedded.expression`. This causes VS Code to incorrectly treat the entire expression as JavaScript for basic language commands such as commenting.

This fix instead changes jsx expressions to only mark the expression itself (and not the braces) as `meta.embedded.expression`. This lets VS Code correctly handle commenting in a few edge cases