### PR TITLE
add distinction between `func()` and `.func()`

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -1465,6 +1465,8 @@ repository:
       end: (?={{functionCallLookup}})
       patterns:
       - include: '#support-function-call-identifiers'
+      - name: entity.name.function.property.ts
+        match: (?=\.)({{propertyIdentifier}})
       - name: entity.name.function.ts
         match: ({{propertyIdentifier}})
     - include: '#comment'


### PR DESCRIPTION
Add the `entity.name.function.property.ts` scope to allow this kind of theme highlighting
![code_ts](https://user-images.githubusercontent.com/17692058/72233691-72732b80-358e-11ea-9f67-6ee1f7d6187b.png)
![code_cpp](https://user-images.githubusercontent.com/17692058/72233639-26c08200-358e-11ea-9a33-fbb58fefa80d.png)

The scope was chosen to be consistent with `variable.other.object` -> `variable.other.object.property` since there's no real standard scope for method-calls.

All tests pass once generated

Honestly I don't even use TS, but my theme is highlighting TS in the VS Code release notes so naturally I want it to look as intended.