### PR TITLE
Fix the operand of a 'delete' operator must be optional error

### DIFF
--- a/build/build.ts
+++ b/build/build.ts
@@ -97,7 +97,7 @@ function getTsxGrammar() {
 
 function getTsGrammar(getVariables: (tsGrammarVariables: MapLike<string>) => MapLike<string>) {
     const tsGrammarBeforeTransformation = readYaml(file(Language.TypeScript, Extension.YamlTmLanguage)) as TmGrammar;
-    return updateGrammarVariables(tsGrammarBeforeTransformation, getVariables(tsGrammarBeforeTransformation.variables));
+    return updateGrammarVariables(tsGrammarBeforeTransformation, getVariables(tsGrammarBeforeTransformation.variables as MapLike<string>));
 }
 
 function replacePatternVariables(pattern: string, variableReplacers: VariableReplacer[]) {

--- a/build/index.d.ts
+++ b/build/index.d.ts
@@ -38,7 +38,7 @@ declare interface TmGrammar {
     scopeName: string;
     fileTypes: string[];
     uuid: string;
-    variables: MapLike<string>;
+    variables?: MapLike<string>;
     patterns?: AnyTmGrammarRule[];
     repository: MapLike<TmGrammarRepositaryRule>;
 }


### PR DESCRIPTION
[Fix](https://github.com/microsoft/TypeScript-TmLanguage/issues/839)
Typescript 4.0 bring a breaking change "delete expression must be optional".  [more details](https://github.com/microsoft/TypeScript/pull/37921)