### PR TITLE
Add 'd' flag from the RegExp Match Indices proposal

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -135,7 +135,7 @@ variables:
     {{functionLikeType}} |
     (:\s*(=>|{{matchingParenthesis}}|(<[^<>]*>)|[^<>(),=])+={{functionOrArrowLookup}})
   arrowFunctionEnd: (?==>|\{|(^\s*(export|function|class|interface|let|var|const|import|enum|namespace|module|type|abstract|declare)\s+))
-  regexpTail: ([gimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$])
+  regexpTail: ([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$])
   completeRegexp: \/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/{{regexpTail}})
 
 patterns:
@@ -1306,7 +1306,7 @@ repository:
         begin: (?<=\))\s*{{completeRegexp}}
         beginCaptures:
           '0': { name: punctuation.definition.string.begin.ts }
-        end: (/)([gimsuy]*)
+        end: (/)([dgimsuy]*)
         endCaptures:
           '1': { name: punctuation.definition.string.end.ts }
           '2': { name: keyword.other.ts }
@@ -2724,7 +2724,7 @@ repository:
       begin: (?<!\+\+|--|})(?<=[=(:,\[?+!]|{{lookBehindReturn}}|{{lookBehindCase}}|=>|&&|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/{{regexpTail}})
       beginCaptures:
         '1': { name: punctuation.definition.string.begin.ts }
-      end: (/)([gimsuy]*)
+      end: (/)([dgimsuy]*)
       endCaptures:
         '1': { name: punctuation.definition.string.end.ts }
         '2': { name: keyword.other.ts}
@@ -2735,7 +2735,7 @@ repository:
       begin: ((?<![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?<={{lookBehindReturn}}|{{lookBehindCase}}))\s*){{completeRegexp}}
       beginCaptures:
         '0': { name: punctuation.definition.string.begin.ts }
-      end: (/)([gimsuy]*)
+      end: (/)([dgimsuy]*)
       endCaptures:
         '1': { name: punctuation.definition.string.end.ts }
         '2': { name: keyword.other.ts }

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -4168,7 +4168,7 @@
                 <key>name</key>
                 <string>string.regexp.ts</string>
                 <key>begin</key>
-                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([gimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
                 <key>beginCaptures</key>
                 <dict>
                   <key>0</key>
@@ -4178,7 +4178,7 @@
                   </dict>
                 </dict>
                 <key>end</key>
-                <string>(/)([gimsuy]*)</string>
+                <string>(/)([dgimsuy]*)</string>
                 <key>endCaptures</key>
                 <dict>
                   <key>1</key>
@@ -8227,7 +8227,7 @@
             <key>name</key>
             <string>string.regexp.ts</string>
             <key>begin</key>
-            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/([gimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -8237,7 +8237,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimsuy]*)</string>
+            <string>(/)([dgimsuy]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>
@@ -8263,7 +8263,7 @@
             <key>name</key>
             <string>string.regexp.ts</string>
             <key>begin</key>
-            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([gimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -8273,7 +8273,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimsuy]*)</string>
+            <string>(/)([dgimsuy]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -4190,7 +4190,7 @@
                 <key>name</key>
                 <string>string.regexp.tsx</string>
                 <key>begin</key>
-                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([gimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
                 <key>beginCaptures</key>
                 <dict>
                   <key>0</key>
@@ -4200,7 +4200,7 @@
                   </dict>
                 </dict>
                 <key>end</key>
-                <string>(/)([gimsuy]*)</string>
+                <string>(/)([dgimsuy]*)</string>
                 <key>endCaptures</key>
                 <dict>
                   <key>1</key>
@@ -8175,7 +8175,7 @@
             <key>name</key>
             <string>string.regexp.tsx</string>
             <key>begin</key>
-            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/([gimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -8185,7 +8185,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimsuy]*)</string>
+            <string>(/)([dgimsuy]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>
@@ -8211,7 +8211,7 @@
             <key>name</key>
             <string>string.regexp.tsx</string>
             <key>begin</key>
-            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([gimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -8221,7 +8221,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([gimsuy]*)</string>
+            <string>(/)([dgimsuy]*)</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>

--- a/tests/baselines/regexp.baseline.txt
+++ b/tests/baselines/regexp.baseline.txt
@@ -2,6 +2,7 @@ original file
 -----------------------------------
 var a = /(?:([a-zA-Z_$][\w$])*)/i;
 var x = /\s*\b(async\s+)?function\b/g;
+var d = /\s*\b(async\s+)?function\b/d;
 -----------------------------------
 
 Grammar: TypeScript.tmLanguage
@@ -58,6 +59,49 @@ Grammar: TypeScript.tmLanguage
                                   ^
                                   source.ts punctuation.terminator.statement.ts
 >var x = /\s*\b(async\s+)?function\b/g;
+ ^^^
+ source.ts meta.var.expr.ts storage.type.ts
+    ^
+    source.ts meta.var.expr.ts
+     ^
+     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.definition.variable.ts variable.other.readwrite.ts
+      ^
+      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+       ^
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
+        ^
+        source.ts meta.var.expr.ts string.regexp.ts
+         ^
+         source.ts meta.var.expr.ts string.regexp.ts punctuation.definition.string.begin.ts
+          ^^
+          source.ts meta.var.expr.ts string.regexp.ts constant.other.character-class.regexp
+            ^
+            source.ts meta.var.expr.ts string.regexp.ts keyword.operator.quantifier.regexp
+             ^^
+             source.ts meta.var.expr.ts string.regexp.ts keyword.control.anchor.regexp
+               ^
+               source.ts meta.var.expr.ts string.regexp.ts meta.group.regexp punctuation.definition.group.regexp
+                ^^^^^
+                source.ts meta.var.expr.ts string.regexp.ts meta.group.regexp
+                     ^^
+                     source.ts meta.var.expr.ts string.regexp.ts meta.group.regexp constant.other.character-class.regexp
+                       ^
+                       source.ts meta.var.expr.ts string.regexp.ts meta.group.regexp keyword.operator.quantifier.regexp
+                        ^
+                        source.ts meta.var.expr.ts string.regexp.ts meta.group.regexp punctuation.definition.group.regexp
+                         ^
+                         source.ts meta.var.expr.ts string.regexp.ts keyword.operator.quantifier.regexp
+                          ^^^^^^^^
+                          source.ts meta.var.expr.ts string.regexp.ts
+                                  ^^
+                                  source.ts meta.var.expr.ts string.regexp.ts keyword.control.anchor.regexp
+                                    ^
+                                    source.ts meta.var.expr.ts string.regexp.ts punctuation.definition.string.end.ts
+                                     ^
+                                     source.ts meta.var.expr.ts string.regexp.ts keyword.other.ts
+                                      ^
+                                      source.ts punctuation.terminator.statement.ts
+>var d = /\s*\b(async\s+)?function\b/d;
  ^^^
  source.ts meta.var.expr.ts storage.type.ts
     ^

--- a/tests/cases/regexp.ts
+++ b/tests/cases/regexp.ts
@@ -1,2 +1,3 @@
 var a = /(?:([a-zA-Z_$][\w$])*)/i;
 var x = /\s*\b(async\s+)?function\b/g;
+var d = /\s*\b(async\s+)?function\b/d;


### PR DESCRIPTION
Adds `d` flag to Regular Expressions, per https://github.com/tc39/proposal-regexp-match-indices per [22.2.3.2.2 RegExpInitialize ( obj, pattern, flags )](https://arai-a.github.io/ecma262-compare/?pr=1713&id=sec-regexpinitialize), Step 5:

> 
![image](https://user-images.githubusercontent.com/3902892/110516287-3ff38e80-80be-11eb-9f33-0cac84a1e11b.png)
