### PR TITLE
Fix line-ending of ThirdPartyNotices.txt

### DIFF
--- a/ThirdPartyNotices.txt
+++ b/ThirdPartyNotices.txt
@@ -2,7 +2,7 @@
 THIRD-PARTY SOFTWARE NOTICES AND INFORMATION
 Do Not Translate or Localize
 
-Latest TypeScript and Javascript Grammar incorporates third party material from the projects listed below. The original copyright notice and the license under which Microsoft received such third party material are set forth below. Microsoft reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.  
+Latest TypeScript and Javascript Grammar incorporates third party material from the projects listed below. The original copyright notice and the license under which Microsoft received such third party material are set forth below. Microsoft reserves all other rights not expressly granted, whether by implication, estoppel or otherwise.
 
 1.	babel-sublime (https://github.com/babel/babel-sublime)
 2.	language-javascript (https://github.com/atom/language-javascript)


### PR DESCRIPTION
Due to the rule defined in https://github.com/microsoft/TypeScript-TmLanguage/blob/10e222a5ac8f4f45b40bd03a76131d07562e5c3e/.gitattributes#L1-L2
this file shows up as modified in down-stream repos (e.g. https://github.com/github/linguist) because it has CRLF endings.

Fixes #865