### PR TITLE
Add syntax highlighting for JSDoc "template" tags with constraints.

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -3028,6 +3028,17 @@ repository:
           # patterns:
           # - name: punctuation.delimiter.object.comma.jsdoc
           #   match: ','
+    # @template {Constraint} Foo
+    - begin: (?x)((@)template)\s+(?={)
+      beginCaptures:
+        '1': { name: storage.type.class.jsdoc }
+        '2': { name: punctuation.definition.block.tag.jsdoc }
+      end: (?=\s|\*/|[^{}\[\]A-Za-z_$])
+      patterns:
+      - include: '#jsdoctype'
+      - name: variable.other.jsdoc
+        # One valid identifier
+        match: ([A-Za-z_$][\w$.\[\]]*)
     # Tags followed by an identifier token
     # -  @<tag> identifier
     - match: |-

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -9097,6 +9097,38 @@
             </dict>
           </dict>
           <dict>
+            <key>begin</key>
+            <string>(?x)((@)template)\s+(?={)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>storage.type.class.jsdoc</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.block.tag.jsdoc</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?=\s|\*/|[^{}\[\]A-Za-z_$])</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#jsdoctype</string>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>variable.other.jsdoc</string>
+                <key>match</key>
+                <string>([A-Za-z_$][\w$.\[\]]*)</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
             <key>match</key>
             <string>(?x)
 (

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -9045,6 +9045,38 @@
             </dict>
           </dict>
           <dict>
+            <key>begin</key>
+            <string>(?x)((@)template)\s+(?={)</string>
+            <key>beginCaptures</key>
+            <dict>
+              <key>1</key>
+              <dict>
+                <key>name</key>
+                <string>storage.type.class.jsdoc</string>
+              </dict>
+              <key>2</key>
+              <dict>
+                <key>name</key>
+                <string>punctuation.definition.block.tag.jsdoc</string>
+              </dict>
+            </dict>
+            <key>end</key>
+            <string>(?=\s|\*/|[^{}\[\]A-Za-z_$])</string>
+            <key>patterns</key>
+            <array>
+              <dict>
+                <key>include</key>
+                <string>#jsdoctype</string>
+              </dict>
+              <dict>
+                <key>name</key>
+                <string>variable.other.jsdoc</string>
+                <key>match</key>
+                <string>([A-Za-z_$][\w$.\[\]]*)</string>
+              </dict>
+            </array>
+          </dict>
+          <dict>
             <key>match</key>
             <string>(?x)
 (


### PR DESCRIPTION
* Add support for highlighting `@template {Foo} Bar` in JSDoc comments (fixes #820)

![JSDoc Template with Constraint](https://user-images.githubusercontent.com/52994294/147332047-e2771f77-e3b9-4957-a88b-88bb0e10f8dd.png)