### PR TITLE
adding 'auto' to .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 # Make sure baseline files have consistent line endings
-*.txt text eol=lf
+*.txt text=auto eol=lf


### PR DESCRIPTION
This should resolve the issue with the ThirdPartyNotices.txt file showing up as "modified" because of line ending changes.

See the documentation here for the change that occurs with the 'auto' value for text.
https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Settostringvalueauto