### PR TITLE
Remove double up of `'` under `docblock`

### DIFF
--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -9381,7 +9381,7 @@
             <key>contentName</key>
             <string>variable.other.jsdoc</string>
             <key>begin</key>
-            <string>((@)(?:default(?:value)?|license|version))\s+(([''"]))</string>
+            <string>((@)(?:default(?:value)?|license|version))\s+((['"]))</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>


### PR DESCRIPTION
There are two single quotes `'` inside a character class
The secondary `'` is redundant
This request removes it

(I am unable to remove the eof newline due to githubs inherit superiority)