### PR TITLE
[fix] fix #956: the case like `as const satisfies T`

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -1240,7 +1240,7 @@ repository:
       captures:
         '1': { name: keyword.control.type.ts }
         '2': { name: variable.other.readwrite.alias.ts }
-      
+
 
   #control statements and loops
   switch-statement:
@@ -1717,7 +1717,7 @@ repository:
       beginCaptures:
         '1': { name: keyword.control.as.ts }
         '2': { name: keyword.control.satisfies.ts }
-      end: (?=^|{{lookAheadEndOfType}}|({{startOfIdentifier}}(as|satisifies)\s+)|(\s+\<))
+      end: (?=^|{{lookAheadEndOfType}}|({{startOfIdentifier}}(as|satisfies)\s+)|(\s+\<))
       patterns:
       - include: '#type'
     - name: keyword.operator.spread.ts
@@ -2703,7 +2703,7 @@ repository:
         '1': { name: entity.name.function.tagged-template.ts }
       end: (?=`)
       patterns:
-      - include: '#type-arguments'    
+      - include: '#type-arguments'
 
   template-substitution-element:
     name: meta.template.expression.ts

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -5583,7 +5583,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(?=^|[;),}\]:?\-\+\&gt;]|\|\||\&amp;\&amp;|\!\=\=|$|((?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(as|satisifies)\s+)|(\s+\&lt;))</string>
+            <string>(?=^|[;),}\]:?\-\+\&gt;]|\|\||\&amp;\&amp;|\!\=\=|$|((?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(as|satisfies)\s+)|(\s+\&lt;))</string>
             <key>patterns</key>
             <array>
               <dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -5529,7 +5529,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(?=^|[;),}\]:?\-\+\&gt;]|\|\||\&amp;\&amp;|\!\=\=|$|((?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(as|satisifies)\s+)|(\s+\&lt;))</string>
+            <string>(?=^|[;),}\]:?\-\+\&gt;]|\|\||\&amp;\&amp;|\!\=\=|$|((?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(as|satisfies)\s+)|(\s+\&lt;))</string>
             <key>patterns</key>
             <array>
               <dict>

--- a/tests/baselines/AsConstSatisfies.baseline.txt
+++ b/tests/baselines/AsConstSatisfies.baseline.txt
@@ -1,0 +1,48 @@
+original file
+-----------------------------------
+let a = {} as const satisfies {};
+
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>let a = {} as const satisfies {};
+ ^^^
+ source.ts meta.var.expr.ts storage.type.ts
+    ^
+    source.ts meta.var.expr.ts
+     ^
+     source.ts meta.var.expr.ts meta.var-single-variable.expr.ts meta.definition.variable.ts variable.other.readwrite.ts
+      ^
+      source.ts meta.var.expr.ts meta.var-single-variable.expr.ts
+       ^
+       source.ts meta.var.expr.ts keyword.operator.assignment.ts
+        ^
+        source.ts meta.var.expr.ts
+         ^
+         source.ts meta.var.expr.ts meta.objectliteral.ts punctuation.definition.block.ts
+          ^
+          source.ts meta.var.expr.ts meta.objectliteral.ts punctuation.definition.block.ts
+           ^
+           source.ts meta.var.expr.ts
+            ^^
+            source.ts meta.var.expr.ts keyword.control.as.ts
+              ^
+              source.ts meta.var.expr.ts
+               ^^^^^
+               source.ts meta.var.expr.ts entity.name.type.ts
+                    ^
+                    source.ts meta.var.expr.ts
+                     ^^^^^^^^^
+                     source.ts meta.var.expr.ts keyword.control.satisfies.ts
+                              ^
+                              source.ts meta.var.expr.ts
+                               ^
+                               source.ts meta.var.expr.ts meta.object.type.ts punctuation.definition.block.ts
+                                ^
+                                source.ts meta.var.expr.ts meta.object.type.ts punctuation.definition.block.ts
+                                 ^
+                                 source.ts punctuation.terminator.statement.ts
+>
+ ^
+ source.ts

--- a/tests/cases/AsConstSatisfies.ts
+++ b/tests/cases/AsConstSatisfies.ts
@@ -1,0 +1,1 @@
+let a = {} as const satisfies {};


### PR DESCRIPTION
It seems that there's a typo in the language definition file, which causes #956. 

fix #956