### PR TITLE
Updates tmThemes to match latest VSCode colors

### DIFF
--- a/TypeScript.YAML-tmTheme
+++ b/TypeScript.YAML-tmTheme
@@ -46,10 +46,11 @@ settings:
 - scope: entity.name.type.enum.ts
   settings: { vsclassificationtype: enum name }
 
-- scope: entity.name.type, meta.template.expression.ts, entity.other.inherited-class.ts
+- scope: meta.template.expression.ts, entity.other.inherited-class.ts
   settings: { vsclassificationtype: identifier }
+- scope: entity
 - scope: variable, meta.definition.variable.name, support.variable, entity.name.variable, constant.other.placeholder
-  settings: { vsclassificationtype: parameter name }
+  settings: { vsclassificationtype: local name }
 - scope: entity.name.function, support.function, support.constant.handlebars, source.powershell variable.other.member, entity.name.operator.custom-literal
   settings: { vsclassificationtype: method name }
 

--- a/TypeScript.YAML-tmTheme
+++ b/TypeScript.YAML-tmTheme
@@ -48,7 +48,6 @@ settings:
 
 - scope: meta.template.expression.ts, entity.other.inherited-class.ts
   settings: { vsclassificationtype: identifier }
-- scope: entity
 - scope: variable, meta.definition.variable.name, support.variable, entity.name.variable, constant.other.placeholder
   settings: { vsclassificationtype: local name }
 - scope: entity.name.function, support.function, support.constant.handlebars, source.powershell variable.other.member, entity.name.operator.custom-literal

--- a/TypeScript.YAML-tmTheme
+++ b/TypeScript.YAML-tmTheme
@@ -5,10 +5,14 @@ name: TypeScript
 uuid: 91489F9C-F403-4CF0-993D-EAAF9149E40E
 
 settings:
-- scope: storage.modifier, storage.type, keyword.control, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression
+- scope: storage.modifier, storage.type, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression
   settings: { vsclassificationtype: keyword }
-- scope: support.type, constant.language, variable.language, variable.language variable.parameter
+- scope: constant.language, variable.language
   settings: { vsclassificationtype: keyword }
+- scope: keyword.control, keyword.operator.expression.delete, keyword.other.using, keyword.other.operator, entity.name.operator
+  settings: { vsclassificationtype: keyword - control }
+- scope: support.class, support.type, entity.name.type, entity.name.namespace, entity.other.attribute, entity.name.scope-resolution, entity.name.class
+  settings: { vsclassificationtype: type }
 
 - scope: string, punctuation.definition.string, constant.character
   settings: { vsclassificationtype: string }
@@ -42,8 +46,12 @@ settings:
 - scope: entity.name.type.enum.ts
   settings: { vsclassificationtype: enum name }
 
-- scope: entity.name.function, entity.name.type, meta.template.expression.ts, variable, entity.other.inherited-class.ts
+- scope: entity.name.type, meta.template.expression.ts, entity.other.inherited-class.ts
   settings: { vsclassificationtype: identifier }
+- scope: variable, meta.definition.variable.name, support.variable, entity.name.variable, constant.other.placeholder
+  settings: { vsclassificationtype: parameter name }
+- scope: entity.name.function, support.function, support.constant.handlebars, source.powershell variable.other.member, entity.name.operator.custom-literal
+  settings: { vsclassificationtype: method name }
 
 - scope: constant.language.undefined.ts, variable.language.arguments.ts, support.type.object
   settings: { vsclassificationtype: identifier }
@@ -54,6 +62,15 @@ settings:
 - scope: entity.other.attribute-name
   settings: { vsclassificationtype: HTML Attribute Name }
 
-- scope: meta.tag string.quoted, meta.tag string.quoted punctuation.definition.string, meta.tag string.quoted constant.character.escape
-  settings: { vsclassificationtype: HTML Attribute Value }
+- scope: meta.tag string.quoted, meta.tag string.quoted punctuation.definition.string, meta.tag string.quoted
+  settings: { vsclassificationtype: string }
+
+- scope: meta.object-literal.key
+  settings: { vsclassificationtype: parameter name }
+
+- scope: constant.character.escape
+  settings: { vsclassificationtype: string - escape character }
+
+- scope: entity.name.label
+  settings: { vsclassificationtype: label name }
 ...

--- a/TypeScript.tmTheme
+++ b/TypeScript.tmTheme
@@ -10,7 +10,7 @@
     <array>
       <dict>
         <key>scope</key>
-        <string>storage.modifier, storage.type, keyword.control, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression</string>
+        <string>storage.modifier, storage.type, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
@@ -19,11 +19,29 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>support.type, constant.language, variable.language, variable.language variable.parameter</string>
+        <string>constant.language, variable.language</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
           <string>keyword</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>keyword.control, keyword.operator.expression.delete, keyword.other.using, keyword.other.operator, entity.name.operator</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>keyword - control</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>support.class, support.type, entity.name.type, entity.name.namespace, entity.other.attribute, entity.name.scope-resolution, entity.name.class</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>type</string>
         </dict>
       </dict>
       <dict>
@@ -136,11 +154,29 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.function, entity.name.type, meta.template.expression.ts, variable, entity.other.inherited-class.ts</string>
+        <string>entity.name.type, meta.template.expression.ts, entity.other.inherited-class.ts</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
           <string>identifier</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>variable, meta.definition.variable.name, support.variable, entity.name.variable, constant.other.placeholder</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>parameter name</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.function, support.function, support.constant.handlebars, source.powershell variable.other.member, entity.name.operator.custom-literal</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>method name</string>
         </dict>
       </dict>
       <dict>
@@ -172,11 +208,38 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>meta.tag string.quoted, meta.tag string.quoted punctuation.definition.string, meta.tag string.quoted constant.character.escape</string>
+        <string>meta.tag string.quoted, meta.tag string.quoted punctuation.definition.string, meta.tag string.quoted</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
-          <string>HTML Attribute Value</string>
+          <string>string</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.object-literal.key</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>parameter name</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>constant.character.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>string - escape character</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.label</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>label name</string>
         </dict>
       </dict>
     </array>

--- a/TypeScript.tmTheme
+++ b/TypeScript.tmTheme
@@ -154,7 +154,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.type, meta.template.expression.ts, entity.other.inherited-class.ts</string>
+        <string>meta.template.expression.ts, entity.other.inherited-class.ts</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
@@ -167,7 +167,7 @@
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
-          <string>parameter name</string>
+          <string>local name</string>
         </dict>
       </dict>
       <dict>

--- a/TypeScriptReact.YAML-tmTheme
+++ b/TypeScriptReact.YAML-tmTheme
@@ -13,7 +13,7 @@ settings:
 - scope: meta.jsx.children.tsx, constant.character.entity.tsx, punctuation.definition.entity.tsx, invalid.illegal.bad-ampersand.tsx
   settings: { vsclassificationtype: xml literal - text }
 
-- scope: invalid.illegal.attribute.tsx, meta.embedded.expression.tsx
+- scope: invalid.illegal.attribute.tsx
   settings: { vsclassificationtype: identifier }
 
 ...

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -10,7 +10,7 @@
     <array>
       <dict>
         <key>scope</key>
-        <string>storage.modifier, storage.type, keyword.control, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression</string>
+        <string>storage.modifier, storage.type, keyword.other, keyword.operator.expression, keyword.operator.new, keyword.generator.asterisk, punctuation.definition.template-expression</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
@@ -19,11 +19,29 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>support.type, constant.language, variable.language, variable.language variable.parameter</string>
+        <string>constant.language, variable.language</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
           <string>keyword</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>keyword.control, keyword.operator.expression.delete, keyword.other.using, keyword.other.operator, entity.name.operator</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>keyword - control</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>support.class, support.type, entity.name.type, entity.name.namespace, entity.other.attribute, entity.name.scope-resolution, entity.name.class</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>type</string>
         </dict>
       </dict>
       <dict>
@@ -136,11 +154,29 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.function, entity.name.type, meta.template.expression.tsx, variable, entity.other.inherited-class.tsx</string>
+        <string>entity.name.type, meta.template.expression.tsx, entity.other.inherited-class.tsx</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
           <string>identifier</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>variable, meta.definition.variable.name, support.variable, entity.name.variable, constant.other.placeholder</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>parameter name</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.function, support.function, support.constant.handlebars, source.powershell variable.other.member, entity.name.operator.custom-literal</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>method name</string>
         </dict>
       </dict>
       <dict>
@@ -172,11 +208,38 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>meta.tag string.quoted, meta.tag string.quoted punctuation.definition.string, meta.tag string.quoted constant.character.escape</string>
+        <string>meta.tag string.quoted, meta.tag string.quoted punctuation.definition.string, meta.tag string.quoted</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
-          <string>HTML Attribute Value</string>
+          <string>string</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.object-literal.key</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>parameter name</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>constant.character.escape</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>string - escape character</string>
+        </dict>
+      </dict>
+      <dict>
+        <key>scope</key>
+        <string>entity.name.label</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>label name</string>
         </dict>
       </dict>
       <dict>
@@ -199,7 +262,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>invalid.illegal.attribute.tsx, meta.embedded.expression.tsx</string>
+        <string>invalid.illegal.attribute.tsx</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -154,7 +154,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.type, meta.template.expression.tsx, entity.other.inherited-class.tsx</string>
+        <string>meta.template.expression.tsx, entity.other.inherited-class.tsx</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
@@ -167,7 +167,7 @@
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
-          <string>parameter name</string>
+          <string>local name</string>
         </dict>
       </dict>
       <dict>


### PR DESCRIPTION
Updates typescript and typescriptreact themes to match VSCode colorization.

There are still slight differences between them but this is very close to match all colors.

This is how it looks now on Visual Studio:
Before --> After
![image](https://user-images.githubusercontent.com/13305542/216507396-2235a520-333c-4710-842a-dd579c018bfb.png)
