### PR TITLE
Changed tsx tag to use html operator

### DIFF
--- a/TypeScriptReact.YAML-tmTheme
+++ b/TypeScriptReact.YAML-tmTheme
@@ -16,4 +16,6 @@ settings:
 - scope: invalid.illegal.attribute.tsx
   settings: { vsclassificationtype: identifier }
 
+- scope: punctuation.definition.tag
+  settings: { vsclassificationtype: html operator }
 ...

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -269,6 +269,15 @@
           <string>identifier</string>
         </dict>
       </dict>
+      <dict>
+        <key>scope</key>
+        <string>punctuation.definition.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>html operator</string>
+        </dict>
+      </dict>
     </array>
   </dict>
 </plist>


### PR DESCRIPTION
Use `html operator` on jsx punctuation tags. 

Barely noticiable on this example but the characters `<`, `>` and `/`, are a different shade of gray.

Before:
![image](https://user-images.githubusercontent.com/13305542/217116460-2de97bfb-60b9-44ce-b2b0-b532d65db582.png)
After:
![image](https://user-images.githubusercontent.com/13305542/217116500-8f62fd1c-8258-41aa-95ae-690e29fc6005.png)

