### PR TITLE
Fixes jsx tags colorization and improves JSDoc comments

### DIFF
--- a/TypeScript.YAML-tmTheme
+++ b/TypeScript.YAML-tmTheme
@@ -32,10 +32,8 @@ settings:
   settings: { vsclassificationtype: comment }
 - scope: comment.block.documentation.ts, other.meta.jsdoc, other.description.jsdoc
   settings: { vsclassificationtype: comment }
-- scope: entity.name.type.instance.jsdoc, variable.other.jsdoc
+- scope: entity.name.type.instance.jsdoc
   settings: { vsclassificationtype: identifier }
-- scope: storage.type.class.jsdoc
-  settings: { vsclassificationtype: xml doc comment - name }
 
 - scope: entity.name.type.class.ts
   settings: { vsclassificationtype: class name }
@@ -56,7 +54,7 @@ settings:
 - scope: constant.language.undefined.ts, variable.language.arguments.ts, support.type.object
   settings: { vsclassificationtype: identifier }
 
-- scope: entity.name.tag
+- scope: entity.name.tag.inline, entity.name.tag.directive
   settings: { vsclassificationtype: HTML Element Name }
 
 - scope: entity.other.attribute-name

--- a/TypeScript.tmTheme
+++ b/TypeScript.tmTheme
@@ -109,20 +109,11 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.type.instance.jsdoc, variable.other.jsdoc</string>
+        <string>entity.name.type.instance.jsdoc</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
           <string>identifier</string>
-        </dict>
-      </dict>
-      <dict>
-        <key>scope</key>
-        <string>storage.type.class.jsdoc</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>xml doc comment - name</string>
         </dict>
       </dict>
       <dict>
@@ -190,7 +181,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.tag</string>
+        <string>entity.name.tag.inline, entity.name.tag.directive</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -109,20 +109,11 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.type.instance.jsdoc, variable.other.jsdoc</string>
+        <string>entity.name.type.instance.jsdoc</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>
           <string>identifier</string>
-        </dict>
-      </dict>
-      <dict>
-        <key>scope</key>
-        <string>storage.type.class.jsdoc</string>
-        <key>settings</key>
-        <dict>
-          <key>vsclassificationtype</key>
-          <string>xml doc comment - name</string>
         </dict>
       </dict>
       <dict>
@@ -190,7 +181,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>entity.name.tag</string>
+        <string>entity.name.tag.inline, entity.name.tag.directive</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>


### PR DESCRIPTION
Fixed Jsx tag colorzation. They display inconsistent colors for open and closed tags. 

Improved JSDoc comments:
- Variables now display `local name` color instead of `identifier`.
- JSDoc directives now use `HTML Element Name`.

Before --> After
![image](https://user-images.githubusercontent.com/13305542/219227940-1f5bc69e-6e0c-4b76-848a-c2c77ac0590c.png)
