### PR TITLE
Added meta.tag to TypeScriptReact.thTheme

### DIFF
--- a/TypeScriptReact.YAML-tmTheme
+++ b/TypeScriptReact.YAML-tmTheme
@@ -18,4 +18,7 @@ settings:
 
 - scope: punctuation.definition.tag
   settings: { vsclassificationtype: html operator }
+
+- scope: meta.tag
+  settings: { vsclassificationtype: HTML Element Name }
 ...

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -269,6 +269,15 @@
           <string>html operator</string>
         </dict>
       </dict>
+      <dict>
+        <key>scope</key>
+        <string>meta.tag</string>
+        <key>settings</key>
+        <dict>
+          <key>vsclassificationtype</key>
+          <string>HTML Element Name</string>
+        </dict>
+      </dict>
     </array>
   </dict>
 </plist>


### PR DESCRIPTION
Fixes non `support.class` tags in typescript react files:

Before --> After
![image](https://user-images.githubusercontent.com/13305542/220778376-6d7d4271-ec8f-4813-91eb-384272d00adf.png)
