### PR TITLE
Fix `undefined` keyword highlighting

### DIFF
--- a/TypeScript.YAML-tmTheme
+++ b/TypeScript.YAML-tmTheme
@@ -51,7 +51,7 @@ settings:
 - scope: entity.name.function, support.function, support.constant.handlebars, source.powershell variable.other.member, entity.name.operator.custom-literal
   settings: { vsclassificationtype: method name }
 
-- scope: constant.language.undefined.ts, variable.language.arguments.ts, support.type.object
+- scope: variable.language.arguments.ts, support.type.object
   settings: { vsclassificationtype: identifier }
 
 - scope: entity.name.tag.inline, entity.name.tag.directive

--- a/TypeScript.tmTheme
+++ b/TypeScript.tmTheme
@@ -172,7 +172,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>constant.language.undefined.ts, variable.language.arguments.ts, support.type.object</string>
+        <string>variable.language.arguments.ts, support.type.object</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>

--- a/TypeScriptReact.tmTheme
+++ b/TypeScriptReact.tmTheme
@@ -172,7 +172,7 @@
       </dict>
       <dict>
         <key>scope</key>
-        <string>constant.language.undefined.tsx, variable.language.arguments.tsx, support.type.object</string>
+        <string>variable.language.arguments.tsx, support.type.object</string>
         <key>settings</key>
         <dict>
           <key>vsclassificationtype</key>


### PR DESCRIPTION
Removes `constant.language.undefined.ts` from the scope so that the `constant.language` scope can pick it up.

Fixes: https://developercommunity.visualstudio.com/t/JavaScript:-undefined-not-highlighted-/10358005

VS before :
![image](https://github.com/microsoft/TypeScript-TmLanguage/assets/13305542/ff7b2c82-a052-4296-acca-e6cda5d4d6f0)

VS After:
![image](https://github.com/microsoft/TypeScript-TmLanguage/assets/13305542/e5cd368a-cf84-41e8-a809-746b889ea7f6)
