### PR TITLE
Override Linguist classification

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,7 @@
 # Make sure baseline files have consistent line endings
 *.txt text eol=lf
+
+# Override classification
+*.YAML-tmLanguage linguist-language=YAML
+*.YAML-tmTheme linguist-language=YAML
+*.YAML-tmPreferences linguist-language=YAML


### PR DESCRIPTION
This PR [overrides the Linguist classification](https://github.com/github-linguist/linguist/blob/master/docs/overrides.md). This makes it possible - for example -, for the following file to get proper syntax highlighting on GitHub (currently no syntax highlighting is applied to this file):
https://github.com/microsoft/TypeScript-TmLanguage/blob/master/TypeScript.YAML-tmTheme

Example (from my fork):
https://github.com/scripthunter7/TypeScript-TmLanguage/blob/master/TypeScript.YAML-tmTheme

