### PR TITLE
Make `regex` lookahead check more strict

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -140,7 +140,7 @@ variables:
     {{functionLikeType}} |
     (:\s*(=>|{{matchingParenthesis}}|(<[^<>]*>)|[^<>(),=])+={{functionOrArrowLookup}})
   arrowFunctionEnd: (?==>|\{|(^\s*(export|function|class|interface|let|var|{{usingKeyword}}|{{awaitUsingKeyword}}|const|import|enum|namespace|module|type|abstract|declare)\s+))
-  regexpTail: ([dgimsuy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$])
+  regexpTail: (?!\*)[dgimsuy]*((?!\/)|(?=\/\*))(?!\s*[a-zA-Z0-9_$])
   completeRegexp: \/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/{{regexpTail}})
 
 patterns:


### PR DESCRIPTION
Fixes https://github.com/microsoft/vscode/issues/204813
> Regex on new line breaks js/ts highlighter

