### PR TITLE
Support "Arbitrary Module Namespace Identifiers"

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -15,7 +15,6 @@ variables:
   propertyIdentifier: '\#?{{identifier}}'
   constantPropertyIdentifier: '\#?{{constantIdentifier}}'
   quotedStrings: (\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`)
-  aliasString: \'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"
   nonIdentifierPropertyName: '{{quotedStrings}}|(\[([^\[\]]|\[[^\[\]]*\])+\])'
   label: ({{identifier}})\s*(:)
   hexNumber: \b(?<!\$)0(?:x|X)[0-9a-fA-F][0-9a-fA-F_]*(n)?\b(?!\$)
@@ -1258,23 +1257,23 @@ repository:
     patterns:
     - include: '#comment'
     #(default|*|name) as alias
-    - match: '{{startOfIdentifier}}(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b{{identifier}})|({{aliasString}})))\s+(as)\s+(?:(default{{endOfIdentifier}})|({{identifier}})|({{aliasString}}))'
+    - match: '{{startOfIdentifier}}(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b{{identifier}})|({{quotedStrings}})))\s+(as)\s+(?:(default{{endOfIdentifier}})|({{identifier}})|({{quotedStrings}}))'
       captures:
         '1': { name: keyword.control.type.ts }
         '2': { name: keyword.control.default.ts }
         '3': { name: constant.language.import-export-all.ts }
         '4': { name: variable.other.readwrite.ts }
         '5': { name: string.quoted.alias.ts }
-        '6': { name: keyword.control.as.ts }
-        '7': { name: keyword.control.default.ts }
-        '8': { name: variable.other.readwrite.alias.ts }
-        '9': { name: string.quoted.alias.ts }
+        '12': { name: keyword.control.as.ts }
+        '13': { name: keyword.control.default.ts }
+        '14': { name: variable.other.readwrite.alias.ts }
+        '15': { name: string.quoted.alias.ts }
     - include: '#punctuation-comma'
     - name: constant.language.import-export-all.ts
       match: \*
     - name: keyword.control.default.ts
       match: \b(default)\b
-    - match: '(?:(\btype)\s+)?(?:({{identifier}})|({{aliasString}}))'
+    - match: '(?:(\btype)\s+)?(?:({{identifier}})|({{quotedStrings}}))'
       captures:
         '1': { name: keyword.control.type.ts }
         '2': { name: variable.other.readwrite.alias.ts }

--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -15,6 +15,7 @@ variables:
   propertyIdentifier: '\#?{{identifier}}'
   constantPropertyIdentifier: '\#?{{constantIdentifier}}'
   quotedStrings: (\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`)
+  aliasString: \'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"
   nonIdentifierPropertyName: '{{quotedStrings}}|(\[([^\[\]]|\[[^\[\]]*\])+\])'
   label: ({{identifier}})\s*(:)
   hexNumber: \b(?<!\$)0(?:x|X)[0-9a-fA-F][0-9a-fA-F_]*(n)?\b(?!\$)
@@ -1257,24 +1258,27 @@ repository:
     patterns:
     - include: '#comment'
     #(default|*|name) as alias
-    - match: '{{startOfIdentifier}}(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b{{identifier}})))\s+(as)\s+(?:(default{{endOfIdentifier}})|({{identifier}}))'
+    - match: '{{startOfIdentifier}}(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b{{identifier}})|({{aliasString}})))\s+(as)\s+(?:(default{{endOfIdentifier}})|({{identifier}})|({{aliasString}}))'
       captures:
         '1': { name: keyword.control.type.ts }
         '2': { name: keyword.control.default.ts }
         '3': { name: constant.language.import-export-all.ts }
         '4': { name: variable.other.readwrite.ts }
-        '5': { name: keyword.control.as.ts }
-        '6': { name: keyword.control.default.ts }
-        '7': { name: variable.other.readwrite.alias.ts }
+        '5': { name: string.quoted.alias.ts }
+        '6': { name: keyword.control.as.ts }
+        '7': { name: keyword.control.default.ts }
+        '8': { name: variable.other.readwrite.alias.ts }
+        '9': { name: string.quoted.alias.ts }
     - include: '#punctuation-comma'
     - name: constant.language.import-export-all.ts
       match: \*
     - name: keyword.control.default.ts
       match: \b(default)\b
-    - match: '(?:(\btype)\s+)?({{identifier}})'
+    - match: '(?:(\btype)\s+)?(?:({{identifier}})|({{aliasString}}))'
       captures:
         '1': { name: keyword.control.type.ts }
         '2': { name: variable.other.readwrite.alias.ts }
+        '3': { name: string.quoted.alias.ts }
 
 
   #control statements and loops

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -4018,7 +4018,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\")))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)|((\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`))))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*)|((\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`)))</string>
             <key>captures</key>
             <dict>
               <key>1</key>
@@ -4046,22 +4046,22 @@
                 <key>name</key>
                 <string>string.quoted.alias.ts</string>
               </dict>
-              <key>6</key>
+              <key>12</key>
               <dict>
                 <key>name</key>
                 <string>keyword.control.as.ts</string>
               </dict>
-              <key>7</key>
+              <key>13</key>
               <dict>
                 <key>name</key>
                 <string>keyword.control.default.ts</string>
               </dict>
-              <key>8</key>
+              <key>14</key>
               <dict>
                 <key>name</key>
                 <string>variable.other.readwrite.alias.ts</string>
               </dict>
-              <key>9</key>
+              <key>15</key>
               <dict>
                 <key>name</key>
                 <string>string.quoted.alias.ts</string>
@@ -4086,7 +4086,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?:(\btype)\s+)?(?:([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
+            <string>(?:(\btype)\s+)?(?:([_$[:alpha:]][_$[:alnum:]]*)|((\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`)))</string>
             <key>captures</key>
             <dict>
               <key>1</key>

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -4018,7 +4018,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\")))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
             <key>captures</key>
             <dict>
               <key>1</key>
@@ -4044,17 +4044,27 @@
               <key>5</key>
               <dict>
                 <key>name</key>
-                <string>keyword.control.as.ts</string>
+                <string>string.quoted.alias.ts</string>
               </dict>
               <key>6</key>
               <dict>
                 <key>name</key>
-                <string>keyword.control.default.ts</string>
+                <string>keyword.control.as.ts</string>
               </dict>
               <key>7</key>
               <dict>
                 <key>name</key>
+                <string>keyword.control.default.ts</string>
+              </dict>
+              <key>8</key>
+              <dict>
+                <key>name</key>
                 <string>variable.other.readwrite.alias.ts</string>
+              </dict>
+              <key>9</key>
+              <dict>
+                <key>name</key>
+                <string>string.quoted.alias.ts</string>
               </dict>
             </dict>
           </dict>
@@ -4076,7 +4086,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?:(\btype)\s+)?([_$[:alpha:]][_$[:alnum:]]*)</string>
+            <string>(?:(\btype)\s+)?(?:([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
             <key>captures</key>
             <dict>
               <key>1</key>
@@ -4088,6 +4098,11 @@
               <dict>
                 <key>name</key>
                 <string>variable.other.readwrite.alias.ts</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>string.quoted.alias.ts</string>
               </dict>
             </dict>
           </dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -4040,7 +4040,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\")))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
             <key>captures</key>
             <dict>
               <key>1</key>
@@ -4066,17 +4066,27 @@
               <key>5</key>
               <dict>
                 <key>name</key>
-                <string>keyword.control.as.tsx</string>
+                <string>string.quoted.alias.tsx</string>
               </dict>
               <key>6</key>
               <dict>
                 <key>name</key>
-                <string>keyword.control.default.tsx</string>
+                <string>keyword.control.as.tsx</string>
               </dict>
               <key>7</key>
               <dict>
                 <key>name</key>
+                <string>keyword.control.default.tsx</string>
+              </dict>
+              <key>8</key>
+              <dict>
+                <key>name</key>
                 <string>variable.other.readwrite.alias.tsx</string>
+              </dict>
+              <key>9</key>
+              <dict>
+                <key>name</key>
+                <string>string.quoted.alias.tsx</string>
               </dict>
             </dict>
           </dict>
@@ -4098,7 +4108,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?:(\btype)\s+)?([_$[:alpha:]][_$[:alnum:]]*)</string>
+            <string>(?:(\btype)\s+)?(?:([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
             <key>captures</key>
             <dict>
               <key>1</key>
@@ -4110,6 +4120,11 @@
               <dict>
                 <key>name</key>
                 <string>variable.other.readwrite.alias.tsx</string>
+              </dict>
+              <key>3</key>
+              <dict>
+                <key>name</key>
+                <string>string.quoted.alias.tsx</string>
               </dict>
             </dict>
           </dict>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -4040,7 +4040,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\")))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
+            <string>(?&lt;![_$[:alnum:]])(?:(?&lt;=\.\.\.)|(?&lt;!\.))(?:(?:(\btype)\s+)?(?:(\bdefault)|(\*)|(\b[_$[:alpha:]][_$[:alnum:]]*)|((\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`))))\s+(as)\s+(?:(default(?![_$[:alnum:]])(?:(?=\.\.\.)|(?!\.)))|([_$[:alpha:]][_$[:alnum:]]*)|((\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`)))</string>
             <key>captures</key>
             <dict>
               <key>1</key>
@@ -4068,22 +4068,22 @@
                 <key>name</key>
                 <string>string.quoted.alias.tsx</string>
               </dict>
-              <key>6</key>
+              <key>12</key>
               <dict>
                 <key>name</key>
                 <string>keyword.control.as.tsx</string>
               </dict>
-              <key>7</key>
+              <key>13</key>
               <dict>
                 <key>name</key>
                 <string>keyword.control.default.tsx</string>
               </dict>
-              <key>8</key>
+              <key>14</key>
               <dict>
                 <key>name</key>
                 <string>variable.other.readwrite.alias.tsx</string>
               </dict>
-              <key>9</key>
+              <key>15</key>
               <dict>
                 <key>name</key>
                 <string>string.quoted.alias.tsx</string>
@@ -4108,7 +4108,7 @@
           </dict>
           <dict>
             <key>match</key>
-            <string>(?:(\btype)\s+)?(?:([_$[:alpha:]][_$[:alnum:]]*)|(\'(?:[^\'\\]|\\.)*\'|\"(?:[^\"\\]|\\.)*\"))</string>
+            <string>(?:(\btype)\s+)?(?:([_$[:alpha:]][_$[:alnum:]]*)|((\'([^\'\\]|\\.)*\')|(\"([^\"\\]|\\.)*\")|(\`([^\`\\]|\\.)*\`)))</string>
             <key>captures</key>
             <dict>
               <key>1</key>

--- a/tests/baselines/arbitraryModuleNamespaceIdentifiers.baseline.txt
+++ b/tests/baselines/arbitraryModuleNamespaceIdentifiers.baseline.txt
@@ -1,0 +1,412 @@
+original file
+-----------------------------------
+import { "a..." as a } from "./foo";
+import { type "b..." as b } from "./foo";
+
+export { a as "a..." };
+export { "b..." } from "./foo";
+export { "c..." as c } from "./foo";
+export { "d..." as "d..." } from "./foo";
+
+export { type a as "a..." };
+export { type "b..." } from "./foo";
+export { type "c..." as c } from "./foo";
+export { type "d..." as "d..." } from "./foo";
+
+export * as "a..." from "./foo";
+
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>import { "a..." as a } from "./foo";
+ ^^^^^^
+ source.ts meta.import.ts keyword.control.import.ts
+       ^
+       source.ts meta.import.ts
+        ^
+        source.ts meta.import.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.import.ts meta.block.ts
+          ^^^^^^
+          source.ts meta.import.ts meta.block.ts string.quoted.alias.ts
+                ^
+                source.ts meta.import.ts meta.block.ts
+                 ^^
+                 source.ts meta.import.ts meta.block.ts keyword.control.as.ts
+                   ^
+                   source.ts meta.import.ts meta.block.ts
+                    ^
+                    source.ts meta.import.ts meta.block.ts variable.other.readwrite.alias.ts
+                     ^
+                     source.ts meta.import.ts meta.block.ts
+                      ^
+                      source.ts meta.import.ts meta.block.ts punctuation.definition.block.ts
+                       ^
+                       source.ts meta.import.ts
+                        ^^^^
+                        source.ts meta.import.ts keyword.control.from.ts
+                            ^
+                            source.ts meta.import.ts
+                             ^
+                             source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                              ^^^^^
+                              source.ts meta.import.ts string.quoted.double.ts
+                                   ^
+                                   source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                    ^
+                                    source.ts punctuation.terminator.statement.ts
+>import { type "b..." as b } from "./foo";
+ ^^^^^^
+ source.ts meta.import.ts keyword.control.import.ts
+       ^
+       source.ts meta.import.ts
+        ^
+        source.ts meta.import.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.import.ts meta.block.ts
+          ^^^^
+          source.ts meta.import.ts meta.block.ts keyword.control.type.ts
+              ^
+              source.ts meta.import.ts meta.block.ts
+               ^^^^^^
+               source.ts meta.import.ts meta.block.ts string.quoted.alias.ts
+                     ^
+                     source.ts meta.import.ts meta.block.ts
+                      ^^
+                      source.ts meta.import.ts meta.block.ts keyword.control.as.ts
+                        ^
+                        source.ts meta.import.ts meta.block.ts
+                         ^
+                         source.ts meta.import.ts meta.block.ts variable.other.readwrite.alias.ts
+                          ^
+                          source.ts meta.import.ts meta.block.ts
+                           ^
+                           source.ts meta.import.ts meta.block.ts punctuation.definition.block.ts
+                            ^
+                            source.ts meta.import.ts
+                             ^^^^
+                             source.ts meta.import.ts keyword.control.from.ts
+                                 ^
+                                 source.ts meta.import.ts
+                                  ^
+                                  source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                   ^^^^^
+                                   source.ts meta.import.ts string.quoted.double.ts
+                                        ^
+                                        source.ts meta.import.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                         ^
+                                         source.ts punctuation.terminator.statement.ts
+>
+ ^
+ source.ts
+>export { a as "a..." };
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^
+          source.ts meta.export.ts meta.block.ts variable.other.readwrite.ts
+           ^
+           source.ts meta.export.ts meta.block.ts
+            ^^
+            source.ts meta.export.ts meta.block.ts keyword.control.as.ts
+              ^
+              source.ts meta.export.ts meta.block.ts
+               ^^^^^^
+               source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                     ^
+                     source.ts meta.export.ts meta.block.ts
+                      ^
+                      source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                       ^
+                       source.ts punctuation.terminator.statement.ts
+>export { "b..." } from "./foo";
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^^^^^^
+          source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                ^
+                source.ts meta.export.ts meta.block.ts
+                 ^
+                 source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                  ^
+                  source.ts meta.export.ts
+                   ^^^^
+                   source.ts meta.export.ts keyword.control.from.ts
+                       ^
+                       source.ts meta.export.ts
+                        ^
+                        source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                         ^^^^^
+                         source.ts meta.export.ts string.quoted.double.ts
+                              ^
+                              source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                               ^
+                               source.ts punctuation.terminator.statement.ts
+>export { "c..." as c } from "./foo";
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^^^^^^
+          source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                ^
+                source.ts meta.export.ts meta.block.ts
+                 ^^
+                 source.ts meta.export.ts meta.block.ts keyword.control.as.ts
+                   ^
+                   source.ts meta.export.ts meta.block.ts
+                    ^
+                    source.ts meta.export.ts meta.block.ts variable.other.readwrite.alias.ts
+                     ^
+                     source.ts meta.export.ts meta.block.ts
+                      ^
+                      source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                       ^
+                       source.ts meta.export.ts
+                        ^^^^
+                        source.ts meta.export.ts keyword.control.from.ts
+                            ^
+                            source.ts meta.export.ts
+                             ^
+                             source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                              ^^^^^
+                              source.ts meta.export.ts string.quoted.double.ts
+                                   ^
+                                   source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                    ^
+                                    source.ts punctuation.terminator.statement.ts
+>export { "d..." as "d..." } from "./foo";
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^^^^^^
+          source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                ^
+                source.ts meta.export.ts meta.block.ts
+                 ^^
+                 source.ts meta.export.ts meta.block.ts keyword.control.as.ts
+                   ^
+                   source.ts meta.export.ts meta.block.ts
+                    ^^^^^^
+                    source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                          ^
+                          source.ts meta.export.ts meta.block.ts
+                           ^
+                           source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                            ^
+                            source.ts meta.export.ts
+                             ^^^^
+                             source.ts meta.export.ts keyword.control.from.ts
+                                 ^
+                                 source.ts meta.export.ts
+                                  ^
+                                  source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                   ^^^^^
+                                   source.ts meta.export.ts string.quoted.double.ts
+                                        ^
+                                        source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                         ^
+                                         source.ts punctuation.terminator.statement.ts
+>
+ ^
+ source.ts
+>export { type a as "a..." };
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^^^^
+          source.ts meta.export.ts meta.block.ts keyword.control.type.ts
+              ^
+              source.ts meta.export.ts meta.block.ts
+               ^
+               source.ts meta.export.ts meta.block.ts variable.other.readwrite.ts
+                ^
+                source.ts meta.export.ts meta.block.ts
+                 ^^
+                 source.ts meta.export.ts meta.block.ts keyword.control.as.ts
+                   ^
+                   source.ts meta.export.ts meta.block.ts
+                    ^^^^^^
+                    source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                          ^
+                          source.ts meta.export.ts meta.block.ts
+                           ^
+                           source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                            ^
+                            source.ts punctuation.terminator.statement.ts
+>export { type "b..." } from "./foo";
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^^^^
+          source.ts meta.export.ts meta.block.ts keyword.control.type.ts
+              ^
+              source.ts meta.export.ts meta.block.ts
+               ^^^^^^
+               source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                     ^
+                     source.ts meta.export.ts meta.block.ts
+                      ^
+                      source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                       ^
+                       source.ts meta.export.ts
+                        ^^^^
+                        source.ts meta.export.ts keyword.control.from.ts
+                            ^
+                            source.ts meta.export.ts
+                             ^
+                             source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                              ^^^^^
+                              source.ts meta.export.ts string.quoted.double.ts
+                                   ^
+                                   source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                    ^
+                                    source.ts punctuation.terminator.statement.ts
+>export { type "c..." as c } from "./foo";
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^^^^
+          source.ts meta.export.ts meta.block.ts keyword.control.type.ts
+              ^
+              source.ts meta.export.ts meta.block.ts
+               ^^^^^^
+               source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                     ^
+                     source.ts meta.export.ts meta.block.ts
+                      ^^
+                      source.ts meta.export.ts meta.block.ts keyword.control.as.ts
+                        ^
+                        source.ts meta.export.ts meta.block.ts
+                         ^
+                         source.ts meta.export.ts meta.block.ts variable.other.readwrite.alias.ts
+                          ^
+                          source.ts meta.export.ts meta.block.ts
+                           ^
+                           source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                            ^
+                            source.ts meta.export.ts
+                             ^^^^
+                             source.ts meta.export.ts keyword.control.from.ts
+                                 ^
+                                 source.ts meta.export.ts
+                                  ^
+                                  source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                   ^^^^^
+                                   source.ts meta.export.ts string.quoted.double.ts
+                                        ^
+                                        source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                         ^
+                                         source.ts punctuation.terminator.statement.ts
+>export { type "d..." as "d..." } from "./foo";
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+         ^
+         source.ts meta.export.ts meta.block.ts
+          ^^^^
+          source.ts meta.export.ts meta.block.ts keyword.control.type.ts
+              ^
+              source.ts meta.export.ts meta.block.ts
+               ^^^^^^
+               source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                     ^
+                     source.ts meta.export.ts meta.block.ts
+                      ^^
+                      source.ts meta.export.ts meta.block.ts keyword.control.as.ts
+                        ^
+                        source.ts meta.export.ts meta.block.ts
+                         ^^^^^^
+                         source.ts meta.export.ts meta.block.ts string.quoted.alias.ts
+                               ^
+                               source.ts meta.export.ts meta.block.ts
+                                ^
+                                source.ts meta.export.ts meta.block.ts punctuation.definition.block.ts
+                                 ^
+                                 source.ts meta.export.ts
+                                  ^^^^
+                                  source.ts meta.export.ts keyword.control.from.ts
+                                      ^
+                                      source.ts meta.export.ts
+                                       ^
+                                       source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                                        ^^^^^
+                                        source.ts meta.export.ts string.quoted.double.ts
+                                             ^
+                                             source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                              ^
+                                              source.ts punctuation.terminator.statement.ts
+>
+ ^
+ source.ts
+>export * as "a..." from "./foo";
+ ^^^^^^
+ source.ts meta.export.ts keyword.control.export.ts
+       ^
+       source.ts meta.export.ts
+        ^
+        source.ts meta.export.ts constant.language.import-export-all.ts
+         ^
+         source.ts meta.export.ts
+          ^^
+          source.ts meta.export.ts keyword.control.as.ts
+            ^
+            source.ts meta.export.ts
+             ^^^^^^
+             source.ts meta.export.ts string.quoted.alias.ts
+                   ^
+                   source.ts meta.export.ts
+                    ^^^^
+                    source.ts meta.export.ts keyword.control.from.ts
+                        ^
+                        source.ts meta.export.ts
+                         ^
+                         source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.begin.ts
+                          ^^^^^
+                          source.ts meta.export.ts string.quoted.double.ts
+                               ^
+                               source.ts meta.export.ts string.quoted.double.ts punctuation.definition.string.end.ts
+                                ^
+                                source.ts punctuation.terminator.statement.ts
+>
+ ^
+ source.ts

--- a/tests/cases/arbitraryModuleNamespaceIdentifiers.ts
+++ b/tests/cases/arbitraryModuleNamespaceIdentifiers.ts
@@ -1,0 +1,14 @@
+import { "a..." as a } from "./foo";
+import { type "b..." as b } from "./foo";
+
+export { a as "a..." };
+export { "b..." } from "./foo";
+export { "c..." as c } from "./foo";
+export { "d..." as "d..." } from "./foo";
+
+export { type a as "a..." };
+export { type "b..." } from "./foo";
+export { type "c..." as c } from "./foo";
+export { type "d..." as "d..." } from "./foo";
+
+export * as "a..." from "./foo";


### PR DESCRIPTION
This PR implements [Arbitrary Module Namespace Identifiers](https://github.com/tc39/ecma262/pull/2154), which is a JavaScript syntax feature that was added to JavaScript over two years ago (in ES2022). It allows import and export aliases to be strings instead of identifiers.

**Before this PR:**

![](https://github.com/microsoft/TypeScript-TmLanguage/assets/406394/4514b226-99ff-4c1f-907a-e1c15dc72981)

Notice that the string content is incorrectly colored. In particular, the characters `default` in the middle of the string are confusingly highlighted as a keyword. The preceding `type` keyword is also not highlighted as a keyword when it should be.

**After this PR:**

![](https://github.com/microsoft/TypeScript-TmLanguage/assets/406394/59811f51-d223-47c9-8d06-ce7825cc6e4a)

All strings are highlighted as strings, and the `type` keyword is highlighted as a keyword.
