### PR TITLE
Make `regex` lookahead check more strict

### DIFF
--- a/TypeScript.YAML-tmLanguage
+++ b/TypeScript.YAML-tmLanguage
@@ -140,7 +140,7 @@ variables:
     {{functionLikeType}} |
     (:\s*(=>|{{matchingParenthesis}}|(<[^<>]*>)|[^<>(),=])+={{functionOrArrowLookup}})
   arrowFunctionEnd: (?==>|\{|(^\s*(export|function|class|interface|let|var|{{usingKeyword}}|{{awaitUsingKeyword}}|const|import|enum|namespace|module|type|abstract|declare)\s+))
-  regexpTail: ([dgimsuvy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$])
+  regexpTail: (?!\*)([dgimsuvy]*)(?:(?=\s+(?:as|satisfies)\s)|(?!\s*/(?![/*])|\s*[a-zA-Z0-9_$]))
   completeRegexp: \/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/{{regexpTail}})
 
 patterns:
@@ -2796,7 +2796,7 @@ repository:
       begin: (?<!\+\+|--|})(?<=[=(:,\[?+!]|{{lookBehindReturn}}|{{lookBehindCase}}|=>|&&|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/{{regexpTail}})
       beginCaptures:
         '1': { name: punctuation.definition.string.begin.ts }
-      end: (/)([dgimsuvy]*)
+      end: (/)([dgimsuvy]*)|$
       endCaptures:
         '1': { name: punctuation.definition.string.end.ts }
         '2': { name: keyword.other.ts}
@@ -2807,7 +2807,7 @@ repository:
       begin: ((?<![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?<={{lookBehindReturn}}|{{lookBehindCase}}))\s*){{completeRegexp}}
       beginCaptures:
         '0': { name: punctuation.definition.string.begin.ts }
-      end: (/)([dgimsuvy]*)
+      end: (/)([dgimsuvy]*)|$
       endCaptures:
         '1': { name: punctuation.definition.string.end.ts }
         '2': { name: keyword.other.ts }

--- a/TypeScript.tmLanguage
+++ b/TypeScript.tmLanguage
@@ -4380,7 +4380,7 @@
                 <key>name</key>
                 <string>string.regexp.ts</string>
                 <key>begin</key>
-                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuvy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/(?!\*)([dgimsuvy]*)(?:(?=\s+(?:as|satisfies)\s)|(?!\s*/(?![/*])|\s*[a-zA-Z0-9_$])))</string>
                 <key>beginCaptures</key>
                 <dict>
                   <key>0</key>
@@ -8485,7 +8485,7 @@
             <key>name</key>
             <string>string.regexp.ts</string>
             <key>begin</key>
-            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/([dgimsuvy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/(?!\*)([dgimsuvy]*)(?:(?=\s+(?:as|satisfies)\s)|(?!\s*/(?![/*])|\s*[a-zA-Z0-9_$])))</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -8495,7 +8495,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([dgimsuvy]*)</string>
+            <string>(/)([dgimsuvy]*)|$</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>
@@ -8521,7 +8521,7 @@
             <key>name</key>
             <string>string.regexp.ts</string>
             <key>begin</key>
-            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuvy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/(?!\*)([dgimsuvy]*)(?:(?=\s+(?:as|satisfies)\s)|(?!\s*/(?![/*])|\s*[a-zA-Z0-9_$])))</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -8531,7 +8531,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([dgimsuvy]*)</string>
+            <string>(/)([dgimsuvy]*)|$</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>

--- a/TypeScriptReact.tmLanguage
+++ b/TypeScriptReact.tmLanguage
@@ -4402,7 +4402,7 @@
                 <key>name</key>
                 <string>string.regexp.tsx</string>
                 <key>begin</key>
-                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuvy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+                <string>(?&lt;=\))\s*\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/(?!\*)([dgimsuvy]*)(?:(?=\s+(?:as|satisfies)\s)|(?!\s*/(?![/*])|\s*[a-zA-Z0-9_$])))</string>
                 <key>beginCaptures</key>
                 <dict>
                   <key>0</key>
@@ -8433,7 +8433,7 @@
             <key>name</key>
             <string>string.regexp.tsx</string>
             <key>begin</key>
-            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/([dgimsuvy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>(?&lt;!\+\+|--|})(?&lt;=[=(:,\[?+!]|^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case|=&gt;|&amp;&amp;|\|\||\*\/)\s*(\/)(?![\/*])(?=(?:[^\/\\\[\()]|\\.|\[([^\]\\]|\\.)+\]|\(([^\)\\]|\\.)+\))+\/(?!\*)([dgimsuvy]*)(?:(?=\s+(?:as|satisfies)\s)|(?!\s*/(?![/*])|\s*[a-zA-Z0-9_$])))</string>
             <key>beginCaptures</key>
             <dict>
               <key>1</key>
@@ -8443,7 +8443,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([dgimsuvy]*)</string>
+            <string>(/)([dgimsuvy]*)|$</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>
@@ -8469,7 +8469,7 @@
             <key>name</key>
             <string>string.regexp.tsx</string>
             <key>begin</key>
-            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/([dgimsuvy]+|(?![\/\*])|(?=\/\*))(?!\s*[a-zA-Z0-9_$]))</string>
+            <string>((?&lt;![_$[:alnum:])\]]|\+\+|--|}|\*\/)|((?&lt;=^return|[^\._$[:alnum:]]return|^case|[^\._$[:alnum:]]case))\s*)\/(?![\/*])(?=(?:[^\/\\\[]|\\.|\[([^\]\\]|\\.)*\])+\/(?!\*)([dgimsuvy]*)(?:(?=\s+(?:as|satisfies)\s)|(?!\s*/(?![/*])|\s*[a-zA-Z0-9_$])))</string>
             <key>beginCaptures</key>
             <dict>
               <key>0</key>
@@ -8479,7 +8479,7 @@
               </dict>
             </dict>
             <key>end</key>
-            <string>(/)([dgimsuvy]*)</string>
+            <string>(/)([dgimsuvy]*)|$</string>
             <key>endCaptures</key>
             <dict>
               <key>1</key>

--- a/tests/baselines/Issue1024.baseline.txt
+++ b/tests/baselines/Issue1024.baseline.txt
@@ -1,0 +1,76 @@
+original file
+-----------------------------------
+1
+	/ f(/u/g)
+function f(_: RegExp) {
+	return 1;
+}
+
+-----------------------------------
+
+Grammar: TypeScript.tmLanguage
+-----------------------------------
+>1
+ ^
+ source.ts constant.numeric.decimal.ts
+>	/ f(/u/g)
+ ^
+ source.ts
+  ^
+  source.ts keyword.operator.arithmetic.ts
+   ^
+   source.ts
+    ^
+    source.ts meta.function-call.ts entity.name.function.ts
+     ^
+     source.ts meta.brace.round.ts
+      ^
+      source.ts string.regexp.ts punctuation.definition.string.begin.ts
+       ^
+       source.ts string.regexp.ts
+        ^
+        source.ts string.regexp.ts punctuation.definition.string.end.ts
+         ^
+         source.ts string.regexp.ts keyword.other.ts
+          ^
+          source.ts meta.brace.round.ts
+>function f(_: RegExp) {
+ ^^^^^^^^
+ source.ts meta.function.ts storage.type.function.ts
+         ^
+         source.ts meta.function.ts
+          ^
+          source.ts meta.function.ts meta.definition.function.ts entity.name.function.ts
+           ^
+           source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.begin.ts
+            ^
+            source.ts meta.function.ts meta.parameters.ts variable.parameter.ts
+             ^
+             source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts keyword.operator.type.annotation.ts
+              ^
+              source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts
+               ^^^^^^
+               source.ts meta.function.ts meta.parameters.ts meta.type.annotation.ts entity.name.type.ts
+                     ^
+                     source.ts meta.function.ts meta.parameters.ts punctuation.definition.parameters.end.ts
+                      ^
+                      source.ts meta.function.ts
+                       ^
+                       source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+>	return 1;
+ ^
+ source.ts meta.function.ts meta.block.ts
+  ^^^^^^
+  source.ts meta.function.ts meta.block.ts keyword.control.flow.ts
+        ^
+        source.ts meta.function.ts meta.block.ts
+         ^
+         source.ts meta.function.ts meta.block.ts constant.numeric.decimal.ts
+          ^
+          source.ts meta.function.ts meta.block.ts punctuation.terminator.statement.ts
+>}
+ ^
+ source.ts meta.function.ts meta.block.ts punctuation.definition.block.ts
+>
+ ^
+ source.ts

--- a/tests/cases/Issue1024.ts
+++ b/tests/cases/Issue1024.ts
@@ -1,0 +1,5 @@
+1
+    / f(/u/g);
+function f(_: RegExp) {
+    return 1;
+}


### PR DESCRIPTION
Fixes #1024
* #1024

Before:
<img width="305" height="121" alt="image" src="https://github.com/user-attachments/assets/6fe08d66-84f8-40a1-aafe-77eede9d3db2" />

After:
<img width="380" height="152" alt="image" src="https://github.com/user-attachments/assets/bfdf6a3d-7e32-44c4-bde3-721d66db0e19" />



dup:
* #1018